### PR TITLE
Add RSpec matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add RSpec test helpers
+
 # 2.1.1
 
 * Support for a new regex in GOV.UK content schemas

--- a/lib/govuk_schemas/rspec_matchers.rb
+++ b/lib/govuk_schemas/rspec_matchers.rb
@@ -1,0 +1,65 @@
+module GovukSchemas
+  module RSpecMatchers
+    RSpec::Matchers.define :be_valid_against_schema do |schema_name|
+      match do |item|
+        schema = Schema.find(publisher_schema: schema_name)
+        validator = JSON::Validator.fully_validate(schema, item)
+        validator.empty?
+      end
+
+      failure_message do |actual|
+        ValidationErrorMessage.new(schema_name, "schema", actual).message
+      end
+    end
+
+    RSpec::Matchers.define :be_valid_against_links_schema do |schema_name|
+      match do |item|
+        schema = Schema.find(links_schema: schema_name)
+        validator = JSON::Validator.fully_validate(schema, item)
+        validator.empty?
+      end
+
+      failure_message do |actual|
+        ValidationErrorMessage.new(schema_name, "links", actual).message
+      end
+    end
+  end
+
+  class ValidationErrorMessage
+    attr_reader :schema_name, :type, :payload
+
+    def initialize(schema_name, type, payload)
+      @schema_name = schema_name
+      @type = type
+      @payload = payload
+    end
+
+    def message
+      <<~doc
+      expected the payload to be valid against the '#{schema_name}' schema:
+
+      #{formatted_payload}
+
+      Validation errors:
+      #{errors}
+      doc
+    end
+
+  private
+
+    def errors
+      schema = Schema.find(publisher_schema: schema_name)
+      validator = JSON::Validator.fully_validate(schema, payload)
+      validator.map { |message| "- " + humanized_error(message) }.join("\n")
+    end
+
+    def formatted_payload
+      return payload if payload.is_a?(String)
+      JSON.pretty_generate(payload)
+    end
+
+    def humanized_error(message)
+      message.gsub("The property '#/'", "The item")
+    end
+  end
+end

--- a/spec/lib/rspec_matchers_spec.rb
+++ b/spec/lib/rspec_matchers_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'govuk_schemas/rspec_matchers'
+
+RSpec.describe GovukSchemas::RSpecMatchers do
+  include GovukSchemas::RSpecMatchers
+
+  describe '#be_valid_against_schema' do
+    it 'detects an valid schema' do
+      example = GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder").payload
+
+      expect(example).to be_valid_against_schema("placeholder")
+    end
+
+    it 'detects an invalid schema' do
+      example = { obviously_invalid: true }
+
+      expect(example).to_not be_valid_against_schema("placeholder")
+    end
+  end
+
+  describe '#be_valid_against_links_schema' do
+    it 'detects an valid schema for links' do
+      example = GovukSchemas::RandomExample.for_schema(links_schema: "placeholder").payload
+
+      expect(example).to be_valid_against_links_schema("placeholder")
+    end
+
+    it 'detects an invalid schema for links' do
+      example = { obviously_invalid: true }
+
+      expect(example).to_not be_valid_against_links_schema("placeholder")
+    end
+  end
+end


### PR DESCRIPTION
This adds matchers to test a payload against the schemas. It is meant as a replacement for the test helpers in https://github.com/alphagov/govuk-content-schema-test-helpers.

Having this here means that we can start deprecating that gem.