### PR TITLE
Update link to documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gem "govuk_schemas", "~> VERSION"
 
 ## Usage
 
-[Read the documentation!](https://alphagov.github.io/govuk_schemas_gem/frames.html)
+[Read the documentation!](https://alphagov.github.io/govuk_schemas/frames.html)
 
 ## Running the test suite
 


### PR DESCRIPTION
The link to the documentation in the README was out of date, so this updates it
to the correct link.