### PR TITLE
Add method which excludes fields when generating a random example

### DIFF
--- a/lib/govuk_schemas/random_example.rb
+++ b/lib/govuk_schemas/random_example.rb
@@ -34,41 +34,23 @@ module GovukSchemas
       GovukSchemas::RandomExample.new(schema: schema)
     end
 
-    # Return a hash with a random content item
-    #
-    # Example:
-    #
-    #     GovukSchemas::RandomExample.for_schema("detailed_guide", schema_type: "frontend").payload
-    #     # => {"base_path"=>"/e42dd28e", "title"=>"dolor est...", "publishing_app"=>"elit"...}
-    #
-    # @return [Hash] A content item
-    def payload
-      item = @random_generator.payload
-      errors = validation_errors_for(item)
-
-      if errors.any?
-        raise InvalidContentGenerated, error_message(item, errors)
-      end
-
-      item
-    end
-
-    # Return a content item merged with a hash. If the resulting content item
-    # isn't valid against the schema an error will be raised.
+    # Return a content item merged with a hash and with the excluded fields removed.
+    # If the resulting content item isn't valid against the schema an error will be raised.
     #
     # Example:
     #
     #      random = GovukSchemas::RandomExample.for_schema("detailed_guide", schema_type: "frontend")
-    #      random.merge_and_validate(base_path: "/foo")
+    #      random.customise_and_validate({base_path: "/foo"}, ["withdrawn_notice"])
     #      # => {"base_path"=>"/e42dd28e", "title"=>"dolor est...", "publishing_app"=>"elit"...}
     #
     # @param [Hash] hash The hash to merge the random content with
+    # @param [Array] array The array containing fields to exclude
     # @return [Hash] A content item
     # @raise [GovukSchemas::InvalidContentGenerated]
-    def merge_and_validate(user_defined_values)
+    def customise_and_validate(user_defined_values = {}, fields_to_exclude = [])
       random_payload = @random_generator.payload
       item_merged_with_user_input = random_payload.merge(Utils.stringify_keys(user_defined_values))
-
+      item_merged_with_user_input.reject! { |k| fields_to_exclude.include?(k) }
       errors = validation_errors_for(item_merged_with_user_input)
       if errors.any?
 
@@ -85,6 +67,18 @@ module GovukSchemas
 
       item_merged_with_user_input
     end
+
+    # Return a hash with a random content item
+    #
+    # Example:
+    #
+    #     GovukSchemas::RandomExample.for_schema("detailed_guide", schema_type: "frontend").payload
+    #     # => {"base_path"=>"/e42dd28e", "title"=>"dolor est...", "publishing_app"=>"elit"...}
+    #
+    # @return [Hash] A content item
+    # Support backwards compatibility
+    alias :payload :customise_and_validate
+    alias :merge_and_validate :customise_and_validate
 
   private
 

--- a/spec/lib/random_example_spec.rb
+++ b/spec/lib/random_example_spec.rb
@@ -35,4 +35,31 @@ RSpec.describe GovukSchemas::RandomExample do
       }.to raise_error(GovukSchemas::InvalidContentGenerated)
     end
   end
+
+  describe "#customise_and_validate" do
+    it "removes user defined fields for exclusion" do
+      schema = GovukSchemas::Schema.random_schema(schema_type: "notification")
+
+      random_example = GovukSchemas::RandomExample.new(schema: schema).payload
+      # Ensure that the example definitely has the field that the method we are testing will remove.
+      # If we did not add this manually there would only be a 50:50 chance that it would be added by the random generation. This would cause the test to pass by accident 50% of the time.
+      example_with_field = random_example.merge("withdrawn_notice" => {})
+
+      allow_any_instance_of(GovukSchemas::RandomItemGenerator)
+        .to receive(:payload)
+        .and_return(example_with_field)
+
+      item = GovukSchemas::RandomExample.new(schema: schema).customise_and_validate({}, ["withdrawn_notice"])
+
+      expect(item).not_to include("withdrawn_notice")
+    end
+
+    it "raises if the resulting content item won't be valid" do
+      schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
+
+      expect {
+        GovukSchemas::RandomExample.new(schema: schema).customise_and_validate({}, ["base_path"])
+      }.to raise_error(GovukSchemas::InvalidContentGenerated)
+    end
+  end
 end


### PR DESCRIPTION
The existing `merge_and_validate` method allows you to generate an
example with some overridden fields, but it does not allow you to
_remove_ optional fields from the payload.

This commit adds a `customise_and_validate` method which allows you to
do both. This lets you write a test which uses an example which is
missing a specific field such as `withdrawn_notice`, but with all the
other fields randomized.

Mobbed with @Rosa-Fox, @dwhenry and @suzannehamilton.

Does anyone have any feedback on the name of the new method? It's part of the public API so we'd like to make sure it makes sense.

https://trello.com/c/KkhqAl4M/215-do-not-generate-fields-in-randomexample