### PR TITLE
Release version 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# Unreleased
+# 2.2.0
 
 * Add RSpec test helpers
+* Add `customise_and_validate` to bring the functionality to remove fields from a payload which has been generated as a random example
 
 # 2.1.1
 

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "2.1.1".freeze
+  VERSION = "2.2.0".freeze
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/KkhqAl4M/215-do-not-generate-fields-in-randomexample)