### PR TITLE
Allow schema examples to exist in format and examples dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Allow looking up examples to work with schemas stored in `formats/{format}/{schema_type}/examples/` and `examples/{format}/{schema_type}/` to allow schema examples to move.
+
 # 2.2.0
 
 * Add RSpec test helpers

--- a/lib/govuk_schemas/example.rb
+++ b/lib/govuk_schemas/example.rb
@@ -5,7 +5,7 @@ module GovukSchemas
     # @param schema_name [String] like "detailed_guide", "policy" or "publication"
     # @return [Array] array of example content items
     def self.find_all(schema_name)
-      Dir.glob("#{GovukSchemas::CONTENT_SCHEMA_DIR}/formats/#{schema_name}/frontend/examples/*.json").map do |filename|
+      Dir.glob("#{examples_path(schema_name)}/*.json").map do |filename|
         json = File.read(filename)
         JSON.parse(json)
       end
@@ -17,9 +17,22 @@ module GovukSchemas
     # @param example_name [String] the name of the example JSON file
     # @return [Hash] the example content item
     def self.find(schema_name, example_name:)
-      path = "/formats/#{schema_name}/frontend/examples/#{example_name}.json"
-      json = File.read("#{GovukSchemas::CONTENT_SCHEMA_DIR}#{path}")
+      json = File.read("#{examples_path(schema_name)}/#{example_name}.json")
       JSON.parse(json)
+    end
+
+    # Examples are changing location in schemas, this allows this utility
+    # to work with both locations
+    #
+    # @param schema_name [String] like "detailed_guide", "policy" or "publication"
+    # @return [String] the path to use for examples
+    def self.examples_path(schema_name)
+      examples_dir = "#{GovukSchemas::CONTENT_SCHEMA_DIR}/examples"
+      if Dir.exist?(examples_dir)
+        "#{examples_dir}/#{schema_name}/frontend"
+      else
+        "#{GovukSchemas::CONTENT_SCHEMA_DIR}/formats/#{schema_name}/frontend/examples"
+      end
     end
   end
 end

--- a/spec/lib/example_spec.rb
+++ b/spec/lib/example_spec.rb
@@ -17,4 +17,27 @@ RSpec.describe GovukSchemas::Example do
       expect(example_content_item).to be_a(Hash)
     end
   end
+
+  describe ".examples_path" do
+    let(:in_examples) { false }
+    let(:schema_name) { "specialist_document" }
+    before do
+      allow(Dir)
+        .to receive(:exist?)
+        .with("#{GovukSchemas::CONTENT_SCHEMA_DIR}/examples")
+        .and_return(in_examples)
+    end
+
+    subject { described_class.examples_path(schema_name) }
+
+    context "when schema examples are in /examples" do
+      let(:in_examples) { true }
+      it { is_expected.to eq "#{GovukSchemas::CONTENT_SCHEMA_DIR}/examples/#{schema_name}/frontend" }
+    end
+
+    context "when schema examples are not in /examples" do
+      let(:in_examples) { false }
+      it { is_expected.to eq "#{GovukSchemas::CONTENT_SCHEMA_DIR}/formats/#{schema_name}/frontend/examples" }
+    end
+  end
 end


### PR DESCRIPTION
This allows for govuk-content-schemas to change so that examples can
move from within formats and into an examples directory as is being
introduced by https://github.com/alphagov/govuk-content-schemas/pull/634