### PR TITLE
Switch the order of payload and errors in error output

### DIFF
--- a/lib/govuk_schemas/random_example.rb
+++ b/lib/govuk_schemas/random_example.rb
@@ -99,15 +99,15 @@ module GovukSchemas
 
     def error_message(item, errors, customised = false)
       details = <<~ERR
-        Validation errors:
-        --------------------------
-
-        #{JSON.pretty_generate(errors)}
-
         Generated payload:
         --------------------------
 
         #{JSON.pretty_generate([item])}
+
+        Validation errors:
+        --------------------------
+
+        #{JSON.pretty_generate(errors)}
       ERR
 
       if customised


### PR DESCRIPTION
The JSON payload is quite big and means you need to scroll up to try
and find the actual errors, this can be a pain when multiple failures
have occurred. Switching the order should make iot easier to see the
errors without the need to scroll (for the last failure at least).

https://trello.com/c/qx627h9B/396-fix-master-build