### PR TITLE
Update json-schema dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # 3.0.1
 
-# change order of output when validation errors occur during random example generation
+* change order of output when validation errors occur during random example generation
 
 # 3.0.0
 
-* Move to block based customisation of randomly generated payloads. This removes the existing methods: `customise_and_validate` and `merge_and_validate`. In additon `GovukSchemas::RandomExample.for_schema(schema)` now returns the payload hash directly.
+* Move to block based customisation of randomly generated payloads. This removes the existing methods: `customise_and_validate` and `merge_and_validate`. In addition `GovukSchemas::RandomExample.for_schema(schema)` now returns the payload hash directly.
 
 # 2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Update json-schema dependency
+
 # 3.0.1
 
 * change order of output when validation errors occur during random example generation

--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # This should be kept in sync with the json-schema version of govuk-content-schemas.
-  spec.add_dependency "json-schema", "~> 2.5.0"
+  spec.add_dependency "json-schema", "~> 2.8.0"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"


### PR DESCRIPTION
A lot of apps have been logging deprecation warnings since upgrading to Ruby 2.4. These are caused by the previous version of json-schema, which referred to the deprecated `Fixnum` class.

I've tested the publishing API and govuk-content-schemas against this version of json-schemas, and the tests all pass.