### PR TITLE
Update documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ gem "govuk_schemas", "~> VERSION"
 
 ## Usage
 
-[Read the documentation!](http://www.rubydoc.info/github/alphagov/govuk_schemas)
+[Read the documentation!](http://www.rubydoc.info/gems/govuk_schemas)
 
 ## Running the test suite
 


### PR DESCRIPTION
For whatever reason, the old documentation link pointed at an older version of the documentation which doesn't seem to have been updated since v.2.3 of this gem.  This updates the link to the more up-to-date version of the documentation that I found.