### PR TITLE
Expose all the valid document types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add `GovukSchemas::DocumentTypes.valid_document_types` (PR #48)
+
 # 3.1.0
 
 * Update json-schema dependency

--- a/lib/govuk_schemas.rb
+++ b/lib/govuk_schemas.rb
@@ -2,6 +2,7 @@ require "govuk_schemas/version"
 require "govuk_schemas/schema"
 require "govuk_schemas/utils"
 require "govuk_schemas/random_example"
+require "govuk_schemas/document_types"
 require "govuk_schemas/example"
 
 module GovukSchemas

--- a/lib/govuk_schemas/document_types.rb
+++ b/lib/govuk_schemas/document_types.rb
@@ -1,0 +1,11 @@
+module GovukSchemas
+  class DocumentTypes
+    # Return all of the document types on GOV.UK
+    def self.valid_document_types
+      @valid_document_types ||= begin
+        filename = "#{GovukSchemas::CONTENT_SCHEMA_DIR}/lib/govuk_content_schemas/allowed_document_types.yml"
+        YAML.load_file(filename)
+      end
+    end
+  end
+end

--- a/spec/lib/document_types_spec.rb
+++ b/spec/lib/document_types_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe GovukSchemas::DocumentTypes do
+  describe '.valid_document_types' do
+    it 'returns all valid document types' do
+      valid_document_types = GovukSchemas::DocumentTypes.valid_document_types
+
+      expect(valid_document_types).to be_a(Array)
+      expect(valid_document_types).to include('guide')
+    end
+  end
+end


### PR DESCRIPTION
We need the document types to validate the configuration in content-publisher.

https://trello.com/c/egKyMGRP