### PR TITLE
 Support generating oneOf in objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Support generating objects with an `oneOf` property.
+
 # 3.2.0
 
 * Add `GovukSchemas::DocumentTypes.valid_document_types` (PR #48)

--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "pry-byebug"
-  spec.add_development_dependency "govuk-lint", "~> 1.2.1"
+  spec.add_development_dependency "govuk-lint", "~> 3.11"
   spec.add_development_dependency "yard", "~> 0.8"
 
   spec.required_ruby_version = ">= 2.3.1"

--- a/lib/govuk_schemas/random_item_generator.rb
+++ b/lib/govuk_schemas/random_item_generator.rb
@@ -90,7 +90,11 @@ module GovukSchemas
         # populate all of the keys in the hash. This isn't quite random, but I
         # haven't found a nice way yet to ensure there's at least n elements in
         # the hash.
-        if subschema['required'].to_a.include?(attribute_name) || subschema['minProperties'] || Random.bool
+        should_generate_value = Random.bool \
+          || subschema['required'].to_a.include?(attribute_name) \
+          || subschema['minProperties'] \
+
+        if should_generate_value
           document[attribute_name] = generate_value(attribute_properties)
         end
       end

--- a/lib/govuk_schemas/random_item_generator.rb
+++ b/lib/govuk_schemas/random_item_generator.rb
@@ -49,7 +49,7 @@ module GovukSchemas
 
       if props['anyOf']
         generate_value(props['anyOf'].sample)
-      elsif props['oneOf']
+      elsif props['oneOf'] && type != 'object'
         # FIXME: Generating valid data for a `oneOf` schema is quite interesting.
         # According to the JSON Schema spec a `oneOf` schema is only valid if
         # the data is valid against *only one* of the clauses. To do this
@@ -85,6 +85,8 @@ module GovukSchemas
     def generate_random_object(subschema)
       document = {}
 
+      one_of_sample = subschema.fetch('oneOf', []).sample || {}
+
       (subschema['properties'] || {}).each do |attribute_name, attribute_properties|
         # TODO: When the schema contains `subschema['minProperties']` we always
         # populate all of the keys in the hash. This isn't quite random, but I
@@ -92,10 +94,17 @@ module GovukSchemas
         # the hash.
         should_generate_value = Random.bool \
           || subschema['required'].to_a.include?(attribute_name) \
+          || (one_of_sample['required'] || {}).to_a.include?(attribute_name) \
+          || (one_of_sample['properties'] || {}).keys.include?(attribute_name) \
           || subschema['minProperties'] \
 
         if should_generate_value
-          document[attribute_name] = generate_value(attribute_properties)
+          one_of_properties = (one_of_sample['properties'] || {})[attribute_name]
+          document[attribute_name] = if one_of_properties
+                                       generate_value(one_of_properties)
+                                     else
+                                       generate_value(attribute_properties)
+                                     end
         end
       end
 

--- a/spec/lib/random_item_generator_spec.rb
+++ b/spec/lib/random_item_generator_spec.rb
@@ -63,5 +63,34 @@ RSpec.describe GovukSchemas::RandomItemGenerator do
 
       expect(generator.payload.keys).to include('my_field')
     end
+
+    it 'handles required properties in oneOf' do
+      schema = {
+        "type" => "object",
+        "properties" => {
+          "my_enum" => {
+            "enum" => %w(a b)
+          },
+          "my_field" => {
+            "type" => "string"
+          },
+        },
+        "oneOf" => [
+          {
+            "properties" => {
+              "my_enum" => {
+                "enum" => %w(a)
+              }
+            },
+            "required" => %w(my_field)
+          }
+        ]
+      }
+
+      generator = GovukSchemas::RandomItemGenerator.new(schema: schema)
+
+      expect(generator.payload['my_enum']).to eq('a')
+      expect(generator.payload.keys).to include('my_field')
+    end
   end
 end


### PR DESCRIPTION
Currently if an object contains a `oneOf` property, the parent `requires` and `properties` get ignored and only the contents of the chosen `oneOf` object are used to generate a value.

This changes the way we generate objects which include a `oneOf` property to take into account both the parent properties as well as the `oneOf` properties.

This was necessary to support alphagov/govuk-content-schemas#910 which uses `oneOf` to describe different required fields with different enum cases which is not something we've done before on the content schemas.

[Trello Card](https://trello.com/c/u0wstyJP/1101-fix-govuk-content-schemas-generation-issue)