### PR TITLE
Change the RSpec::Matchers to be more explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+* Change RSpec::Matchers, rename `be_valid_against_schema` to
+  `be_valid_against_publisher_schema` and add
+  `be_valid_against_frontend_schema` plus
+  `be_valid_against_notification_schema`.
+
 # 3.3.0
 
 * Support generating objects with an `oneOf` property.

--- a/lib/govuk_schemas/rspec_matchers.rb
+++ b/lib/govuk_schemas/rspec_matchers.rb
@@ -1,26 +1,16 @@
 module GovukSchemas
   module RSpecMatchers
-    RSpec::Matchers.define :be_valid_against_schema do |schema_name|
-      match do |item|
-        schema = Schema.find(publisher_schema: schema_name)
-        validator = JSON::Validator.fully_validate(schema, item)
-        validator.empty?
-      end
+    %w[links frontend publisher notification].each do |schema_type|
+      RSpec::Matchers.define "be_valid_against_#{schema_type}_schema".to_sym do |schema_name|
+        match do |item|
+          schema = Schema.find(Hash["#{schema_type}_schema".to_sym, schema_name])
+          validator = JSON::Validator.fully_validate(schema, item)
+          validator.empty?
+        end
 
-      failure_message do |actual|
-        ValidationErrorMessage.new(schema_name, "schema", actual).message
-      end
-    end
-
-    RSpec::Matchers.define :be_valid_against_links_schema do |schema_name|
-      match do |item|
-        schema = Schema.find(links_schema: schema_name)
-        validator = JSON::Validator.fully_validate(schema, item)
-        validator.empty?
-      end
-
-      failure_message do |actual|
-        ValidationErrorMessage.new(schema_name, "links", actual).message
+        failure_message do |actual|
+          ValidationErrorMessage.new(schema_name, "schema", actual).message
+        end
       end
     end
   end

--- a/spec/lib/rspec_matchers_spec.rb
+++ b/spec/lib/rspec_matchers_spec.rb
@@ -4,17 +4,17 @@ require 'govuk_schemas/rspec_matchers'
 RSpec.describe GovukSchemas::RSpecMatchers do
   include GovukSchemas::RSpecMatchers
 
-  describe '#be_valid_against_schema' do
+  describe '#be_valid_against_publisher_schema' do
     it 'detects an valid schema' do
       example = GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder")
 
-      expect(example).to be_valid_against_schema("placeholder")
+      expect(example).to be_valid_against_publisher_schema("placeholder")
     end
 
     it 'detects an invalid schema' do
       example = { obviously_invalid: true }
 
-      expect(example).to_not be_valid_against_schema("placeholder")
+      expect(example).to_not be_valid_against_publisher_schema("placeholder")
     end
   end
 


### PR DESCRIPTION
And add missing ones.

Previously `be_valid_against_schema` meant the publisher schema, so
change the name to make this explicit. Also add matches for the
frontend and notification schemas.