### PR TITLE
Make RandomExample/RandomItemGenerator deterministic (use seed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.0
+
+* Add `seed` parameter to `GovukSchemas::RandomExample` to make the random behaviour deterministic. Given the same seed, the same randomised outputs will be returned ([#56](https://github.com/alphagov/govuk_schemas/pull/56)).
+
 # 4.0.1
 
 * Bump the required Ruby version to >= 2.6.x.

--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rubocop-govuk", "~> 3.8"
+  spec.add_development_dependency "timecop", "~> 0.9"
   spec.add_development_dependency "yard", "~> 0.8"
 
   spec.required_ruby_version = ">= 2.6"

--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rubocop-govuk", "~> 3.8"
-  spec.add_development_dependency "timecop", "~> 0.9"
   spec.add_development_dependency "yard", "~> 0.8"
 
   spec.required_ruby_version = ">= 2.6"

--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "govuk_schemas/version"

--- a/lib/govuk_schemas.rb
+++ b/lib/govuk_schemas.rb
@@ -1,6 +1,5 @@
 require "govuk_schemas/version"
 require "govuk_schemas/schema"
-require "govuk_schemas/utils"
 require "govuk_schemas/random_example"
 require "govuk_schemas/document_types"
 require "govuk_schemas/example"

--- a/lib/govuk_schemas/random.rb
+++ b/lib/govuk_schemas/random.rb
@@ -17,7 +17,7 @@ module GovukSchemas
       end
 
       def time
-        seconds_ago = rand(-5000000..4999999)
+        seconds_ago = rand(-5_000_000..4_999_999)
         (Time.now + seconds_ago).iso8601
       end
 

--- a/lib/govuk_schemas/random.rb
+++ b/lib/govuk_schemas/random.rb
@@ -1,5 +1,3 @@
-require "securerandom"
-
 module GovukSchemas
   # @private
   module Random
@@ -27,7 +25,7 @@ module GovukSchemas
       end
 
       def base_path
-        "/" + rand(1..5).times.map { SecureRandom.uuid }.join("/")
+        "/" + rand(1..5).times.map { uuid }.join("/")
       end
 
       def govuk_subdomain_url
@@ -48,11 +46,21 @@ module GovukSchemas
       end
 
       def anchor
-        "##{SecureRandom.hex}"
+        "##{hex}"
       end
 
       def random_identifier(separator:)
         Utils.parameterize(WORDS.sample(rand(1..10)).join("-")).gsub("-", separator)
+      end
+
+      def uuid
+        # matches uuid regex e.g. e058aad7-ce86-5181-8801-4ddcb3c8f27c
+        # /^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/
+        "#{hex(8)}-#{hex(4)}-1#{hex(3)}-a#{hex(3)}-#{hex(12)}"
+      end
+
+      def hex(length = 10)
+        length.times.map { bool ? random_letter : random_number }.join("")
       end
 
       def string_for_regex(pattern)
@@ -60,7 +68,7 @@ module GovukSchemas
         when "^(placeholder|placeholder_.+)$"
           ["placeholder", "placeholder_#{WORDS.sample}"].sample
         when "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-          SecureRandom.uuid
+          uuid
         when "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
           base_path
         when "^[1-9][0-9]{3}[-/](0[1-9]|1[0-2])[-/](0[1-9]|[12][0-9]|3[0-1])$"
@@ -80,7 +88,7 @@ module GovukSchemas
         when "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)*gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$"
           govuk_subdomain_url
         when '[a-z0-9\-_]'
-          "#{SecureRandom.hex}-#{SecureRandom.hex}"
+          "#{hex}-#{hex}"
         else
           raise <<-DOC
             Don't know how to generate random string for pattern #{pattern.inspect}
@@ -95,6 +103,18 @@ module GovukSchemas
             - Add your regex to `lib/govuk_schemas/random.rb`
           DOC
         end
+      end
+
+    private
+
+      def random_letter
+        letters = ("a".."f").to_a
+        letters[rand(0..letters.count - 1)]
+      end
+
+      def random_number
+        numbers = ("0".."9").to_a
+        numbers[rand(0..numbers.count - 1)]
       end
     end
   end

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -53,7 +53,10 @@ module GovukSchemas
     end
 
     def random_identifier(separator:)
-      Utils.parameterize(WORDS.sample(@random.rand(1..10), random: @random).join("-")).gsub("-", separator)
+      WORDS.sample(@random.rand(1..10), random: @random)
+        .join("-")
+        .gsub(/[^a-z0-9\-_]+/i, "-")
+        .gsub("-", separator)
     end
 
     def uuid

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -1,6 +1,6 @@
 module GovukSchemas
   # @private
-  module Random
+  module RandomContentGenerator
     class << self
       WORDS = %w[Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut suscipit at mauris non bibendum. Ut ac massa est. Aenean tempor imperdiet leo vel interdum. Nam sagittis cursus sem ultricies scelerisque. Quisque porttitor risus vel risus finibus eu sollicitudin nisl aliquet. Sed sed lectus ac dolor molestie interdum. Nam molestie pellentesque purus ac vestibulum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse non tempor eros. Mauris eu orci hendrerit volutpat lorem in tristique libero. Duis a nibh nibh.].freeze
 

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -18,8 +18,8 @@ module GovukSchemas
     end
 
     def time
-      seconds_ago = @random.rand(-5_000_000..4_999_999)
-      (Time.now + seconds_ago).iso8601
+      arbitrary_time = Time.new(2012, 2, 1)
+      (arbitrary_time + @random.rand(0..500_000_000)).iso8601
     end
 
     # TODO: make this more random with query string, optional anchor.

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -1,121 +1,123 @@
 module GovukSchemas
   # @private
-  module RandomContentGenerator
-    class << self
-      WORDS = %w[Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut suscipit at mauris non bibendum. Ut ac massa est. Aenean tempor imperdiet leo vel interdum. Nam sagittis cursus sem ultricies scelerisque. Quisque porttitor risus vel risus finibus eu sollicitudin nisl aliquet. Sed sed lectus ac dolor molestie interdum. Nam molestie pellentesque purus ac vestibulum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse non tempor eros. Mauris eu orci hendrerit volutpat lorem in tristique libero. Duis a nibh nibh.].freeze
+  class RandomContentGenerator
+    WORDS = %w[Lorem ipsum dolor sit amet consectetur adipiscing elit. Ut suscipit at mauris non bibendum. Ut ac massa est. Aenean tempor imperdiet leo vel interdum. Nam sagittis cursus sem ultricies scelerisque. Quisque porttitor risus vel risus finibus eu sollicitudin nisl aliquet. Sed sed lectus ac dolor molestie interdum. Nam molestie pellentesque purus ac vestibulum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse non tempor eros. Mauris eu orci hendrerit volutpat lorem in tristique libero. Duis a nibh nibh.].freeze
 
-      def string_for_type(type)
-        if type == "date-time"
-          time
-        elsif type == "uri"
-          uri
-        else
-          raise "Unknown attribute type `#{type}`"
-        end
+    def initialize(random: Random.new)
+      @random = random
+    end
+
+    def string_for_type(type)
+      if type == "date-time"
+        time
+      elsif type == "uri"
+        uri
+      else
+        raise "Unknown attribute type `#{type}`"
       end
+    end
 
-      def time
-        seconds_ago = rand(-5_000_000..4_999_999)
-        (Time.now + seconds_ago).iso8601
+    def time
+      seconds_ago = @random.rand(-5_000_000..4_999_999)
+      (Time.now + seconds_ago).iso8601
+    end
+
+    # TODO: make this more random with query string, optional anchor.
+    def uri
+      "http://example.com#{base_path}#{anchor}"
+    end
+
+    def base_path
+      "/" + @random.rand(1..5).times.map { uuid }.join("/")
+    end
+
+    def govuk_subdomain_url
+      subdomain = @random.rand(2..4).times.map {
+        ("a".."z").to_a.sample(@random.rand(3..8), random: @random).join
+      }.join(".")
+      "https://#{subdomain}.gov.uk#{base_path}"
+    end
+
+    def string(minimum_chars = nil, maximum_chars = nil)
+      minimum_chars ||= 0
+      maximum_chars ||= 100
+      WORDS.sample(@random.rand(minimum_chars..maximum_chars), random: @random).join(" ")
+    end
+
+    def bool
+      @random.rand(2) == 1
+    end
+
+    def anchor
+      "##{hex}"
+    end
+
+    def random_identifier(separator:)
+      Utils.parameterize(WORDS.sample(@random.rand(1..10), random: @random).join("-")).gsub("-", separator)
+    end
+
+    def uuid
+      # matches uuid regex e.g. e058aad7-ce86-5181-8801-4ddcb3c8f27c
+      # /^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/
+      "#{hex(8)}-#{hex(4)}-1#{hex(3)}-a#{hex(3)}-#{hex(12)}"
+    end
+
+    def hex(length = 10)
+      length.times.map { bool ? random_letter : random_number }.join("")
+    end
+
+    def string_for_regex(pattern)
+      case pattern.to_s
+      when "^(placeholder|placeholder_.+)$"
+        ["placeholder", "placeholder_#{WORDS.sample(random: @random)}"].sample(random: @random)
+      when "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        uuid
+      when "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+        base_path
+      when "^[1-9][0-9]{3}[-/](0[1-9]|1[0-2])[-/](0[1-9]|[12][0-9]|3[0-1])$"
+        Date.today.iso8601
+      when "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        Date.today.iso8601
+      when "^#.+$"
+        anchor
+      when "[a-z-]"
+        random_identifier(separator: "-")
+      when "^[a-z_]+$"
+        random_identifier(separator: "_")
+      when "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
+        base_path
+      when "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)+campaign\\.gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$"
+        govuk_subdomain_url
+      when "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)*gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$"
+        govuk_subdomain_url
+      when '[a-z0-9\-_]'
+        "#{hex}-#{hex}"
+      else
+        raise <<-DOC
+          Don't know how to generate random string for pattern #{pattern.inspect}
+
+          This propably means you've introduced a new regex in  govuk-content-schemas.
+          Because it's very hard to generate a valid string from a regex alone,
+          we have to specify a method to generate random data for each regex in
+          the schemas.
+
+          To fix this:
+
+          - Add your regex to `lib/govuk_schemas/random.rb`
+        DOC
       end
+    end
 
-      # TODO: make this more random with query string, optional anchor.
-      def uri
-        "http://example.com#{base_path}#{anchor}"
-      end
+  private
 
-      def base_path
-        "/" + rand(1..5).times.map { uuid }.join("/")
-      end
+    def random_letter
+      letters = ("a".."f").to_a
+      letters[@random.rand(0..letters.count - 1)]
+    end
 
-      def govuk_subdomain_url
-        subdomain = rand(2..4).times.map {
-          ("a".."z").to_a.sample(rand(3..8)).join
-        }.join(".")
-        "https://#{subdomain}.gov.uk#{base_path}"
-      end
-
-      def string(minimum_chars = nil, maximum_chars = nil)
-        minimum_chars ||= 0
-        maximum_chars ||= 100
-        WORDS.sample(rand(minimum_chars..maximum_chars)).join(" ")
-      end
-
-      def bool
-        rand(2) == 1
-      end
-
-      def anchor
-        "##{hex}"
-      end
-
-      def random_identifier(separator:)
-        Utils.parameterize(WORDS.sample(rand(1..10)).join("-")).gsub("-", separator)
-      end
-
-      def uuid
-        # matches uuid regex e.g. e058aad7-ce86-5181-8801-4ddcb3c8f27c
-        # /^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/
-        "#{hex(8)}-#{hex(4)}-1#{hex(3)}-a#{hex(3)}-#{hex(12)}"
-      end
-
-      def hex(length = 10)
-        length.times.map { bool ? random_letter : random_number }.join("")
-      end
-
-      def string_for_regex(pattern)
-        case pattern.to_s
-        when "^(placeholder|placeholder_.+)$"
-          ["placeholder", "placeholder_#{WORDS.sample}"].sample
-        when "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-          uuid
-        when "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
-          base_path
-        when "^[1-9][0-9]{3}[-/](0[1-9]|1[0-2])[-/](0[1-9]|[12][0-9]|3[0-1])$"
-          Date.today.iso8601
-        when "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
-          Date.today.iso8601
-        when "^#.+$"
-          anchor
-        when "[a-z-]"
-          random_identifier(separator: "-")
-        when "^[a-z_]+$"
-          random_identifier(separator: "_")
-        when "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?$"
-          base_path
-        when "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)+campaign\\.gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$"
-          govuk_subdomain_url
-        when "^https://([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\\.)*gov\\.uk(/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?(\\?([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?(#([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)?)?$"
-          govuk_subdomain_url
-        when '[a-z0-9\-_]'
-          "#{hex}-#{hex}"
-        else
-          raise <<-DOC
-            Don't know how to generate random string for pattern #{pattern.inspect}
-
-            This propably means you've introduced a new regex in  govuk-content-schemas.
-            Because it's very hard to generate a valid string from a regex alone,
-            we have to specify a method to generate random data for each regex in
-            the schemas.
-
-            To fix this:
-
-            - Add your regex to `lib/govuk_schemas/random.rb`
-          DOC
-        end
-      end
-
-    private
-
-      def random_letter
-        letters = ("a".."f").to_a
-        letters[rand(0..letters.count - 1)]
-      end
-
-      def random_number
-        numbers = ("0".."9").to_a
-        numbers[rand(0..numbers.count - 1)]
-      end
+    def random_number
+      numbers = ("0".."9").to_a
+      numbers[@random.rand(0..numbers.count - 1)]
     end
   end
 end

--- a/lib/govuk_schemas/random_example.rb
+++ b/lib/govuk_schemas/random_example.rb
@@ -24,6 +24,11 @@ module GovukSchemas
     #     schema = GovukSchemas::Schema.find(frontend_schema: "detailed_guide")
     #     GovukSchemas::RandomExample.new(schema: schema).payload
     #
+    # If you need a 'consistent' random response, you can set the seed using
+    # (for example) `srand(777)` and know that the payload will always be the
+    # same. Note that timestamps in the payload will continue to reflect the
+    # current time.
+    #
     # @param [Hash] schema A JSON schema.
     # @return [GovukSchemas::RandomExample]
     def initialize(schema:)

--- a/lib/govuk_schemas/random_example.rb
+++ b/lib/govuk_schemas/random_example.rb
@@ -1,4 +1,3 @@
-require "govuk_schemas/random"
 require "govuk_schemas/random_item_generator"
 require "json-schema"
 require "json"
@@ -24,16 +23,17 @@ module GovukSchemas
     #     schema = GovukSchemas::Schema.find(frontend_schema: "detailed_guide")
     #     GovukSchemas::RandomExample.new(schema: schema).payload
     #
-    # If you need a 'consistent' random response, you can set the seed using
-    # (for example) `srand(777)` and know that the payload will always be the
-    # same. Note that timestamps in the payload will continue to reflect the
-    # current time.
+    # Example with seed (for consistent results):
+    #
+    #     schema = GovukSchemas::Schema.find(frontend_schema: "detailed_guide")
+    #     GovukSchemas::RandomExample.new(schema: schema, seed: 777).payload
+    #     GovukSchemas::RandomExample.new(schema: schema, seed: 777).payload # returns same as above
     #
     # @param [Hash] schema A JSON schema.
     # @return [GovukSchemas::RandomExample]
-    def initialize(schema:)
+    def initialize(schema:, seed: nil)
       @schema = schema
-      @random_generator = RandomItemGenerator.new(schema: schema)
+      @random_generator = RandomItemGenerator.new(schema: schema, seed: seed)
     end
 
     # Returns a new `GovukSchemas::RandomExample` object.

--- a/lib/govuk_schemas/random_example.rb
+++ b/lib/govuk_schemas/random_example.rb
@@ -1,4 +1,4 @@
-require "govuk_schemas/random_item_generator"
+require "govuk_schemas/random_schema_generator"
 require "json-schema"
 require "json"
 
@@ -33,7 +33,7 @@ module GovukSchemas
     # @return [GovukSchemas::RandomExample]
     def initialize(schema:, seed: nil)
       @schema = schema
-      @random_generator = RandomItemGenerator.new(schema: schema, seed: seed)
+      @random_generator = RandomSchemaGenerator.new(schema: schema, seed: seed)
     end
 
     # Returns a new `GovukSchemas::RandomExample` object.

--- a/lib/govuk_schemas/random_item_generator.rb
+++ b/lib/govuk_schemas/random_item_generator.rb
@@ -10,8 +10,9 @@ module GovukSchemas
   #
   # @private
   class RandomItemGenerator
-    def initialize(schema:)
+    def initialize(schema:, seed: nil)
       @schema = schema
+      srand(seed) unless seed.nil?
     end
 
     def payload

--- a/lib/govuk_schemas/random_item_generator.rb
+++ b/lib/govuk_schemas/random_item_generator.rb
@@ -98,14 +98,14 @@ module GovukSchemas
           || (one_of_sample["properties"] || {}).keys.include?(attribute_name) \
           || subschema["minProperties"] \
 
-        if should_generate_value
-          one_of_properties = (one_of_sample["properties"] || {})[attribute_name]
-          document[attribute_name] = if one_of_properties
-                                       generate_value(one_of_properties)
-                                     else
-                                       generate_value(attribute_properties)
-                                     end
-        end
+        next unless should_generate_value
+
+        one_of_properties = (one_of_sample["properties"] || {})[attribute_name]
+        document[attribute_name] = if one_of_properties
+                                     generate_value(one_of_properties)
+                                   else
+                                     generate_value(attribute_properties)
+                                   end
       end
 
       document

--- a/lib/govuk_schemas/random_schema_generator.rb
+++ b/lib/govuk_schemas/random_schema_generator.rb
@@ -1,7 +1,7 @@
-require "govuk_schemas/random"
+require "govuk_schemas/random_content_generator"
 
 module GovukSchemas
-  # The RandomItemGenerator takes a JSON schema and outputs a random hash that
+  # The RandomSchemaGenerator takes a JSON schema and outputs a random hash that
   # is valid against said schema.
   #
   # The "randomness" here is quote relative, it's particularly tailored to the
@@ -9,7 +9,7 @@ module GovukSchemas
   # hundred characters to keep the resulting items small.
   #
   # @private
-  class RandomItemGenerator
+  class RandomSchemaGenerator
     def initialize(schema:, seed: nil)
       @schema = schema
       srand(seed) unless seed.nil?
@@ -71,7 +71,7 @@ module GovukSchemas
       elsif type == "array"
         generate_random_array(props)
       elsif type == "boolean"
-        Random.bool
+        RandomContentGenerator.bool
       elsif type == "integer"
         min = props["minimum"] || 0
         max = props["maximum"] || 10
@@ -93,7 +93,7 @@ module GovukSchemas
         # populate all of the keys in the hash. This isn't quite random, but I
         # haven't found a nice way yet to ensure there's at least n elements in
         # the hash.
-        should_generate_value = Random.bool \
+        should_generate_value = RandomContentGenerator.bool \
           || subschema["required"].to_a.include?(attribute_name) \
           || (one_of_sample["required"] || {}).to_a.include?(attribute_name) \
           || (one_of_sample["properties"] || {}).keys.include?(attribute_name) \
@@ -125,11 +125,11 @@ module GovukSchemas
 
     def generate_random_string(props)
       if props["format"]
-        Random.string_for_type(props["format"])
+        RandomContentGenerator.string_for_type(props["format"])
       elsif props["pattern"]
-        Random.string_for_regex(props["pattern"])
+        RandomContentGenerator.string_for_regex(props["pattern"])
       else
-        Random.string(props["minLength"], props["maxLength"])
+        RandomContentGenerator.string(props["minLength"], props["maxLength"])
       end
     end
 

--- a/lib/govuk_schemas/utils.rb
+++ b/lib/govuk_schemas/utils.rb
@@ -1,14 +1,6 @@
 module GovukSchemas
   # @private
   module Utils
-    def self.stringify_keys(hash)
-      new_hash = {}
-      hash.each do |k, v|
-        new_hash[k.to_s] = v
-      end
-      new_hash
-    end
-
     def self.parameterize(string)
       string.gsub(/[^a-z0-9\-_]+/i, "-")
     end

--- a/lib/govuk_schemas/utils.rb
+++ b/lib/govuk_schemas/utils.rb
@@ -1,8 +1,0 @@
-module GovukSchemas
-  # @private
-  module Utils
-    def self.parameterize(string)
-      string.gsub(/[^a-z0-9\-_]+/i, "-")
-    end
-  end
-end

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "4.0.1".freeze
+  VERSION = "4.1.0".freeze
 end

--- a/spec/lib/random_content_generator_spec.rb
+++ b/spec/lib/random_content_generator_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe GovukSchemas::RandomContentGenerator do
   describe ".random_identifier" do
     it "generates a string" do
-      string = GovukSchemas::RandomContentGenerator.random_identifier(separator: "_")
+      string = GovukSchemas::RandomContentGenerator.new.random_identifier(separator: "_")
 
       expect(string).to be_a(String)
     end

--- a/spec/lib/random_content_generator_spec.rb
+++ b/spec/lib/random_content_generator_spec.rb
@@ -1,9 +1,9 @@
 require "spec_helper"
 
-RSpec.describe GovukSchemas::Random do
+RSpec.describe GovukSchemas::RandomContentGenerator do
   describe ".random_identifier" do
     it "generates a string" do
-      string = GovukSchemas::Random.random_identifier(separator: "_")
+      string = GovukSchemas::RandomContentGenerator.random_identifier(separator: "_")
 
       expect(string).to be_a(String)
     end

--- a/spec/lib/random_example_spec.rb
+++ b/spec/lib/random_example_spec.rb
@@ -1,3 +1,4 @@
+require "timecop"
 require "spec_helper"
 
 RSpec.describe GovukSchemas::RandomExample do
@@ -27,12 +28,14 @@ RSpec.describe GovukSchemas::RandomExample do
 
     it "returns the same output if a seed is detected" do
       schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
-      srand(777) # these srand calls would be in the upstream application
-      first_payload = GovukSchemas::RandomExample.new(schema: schema).payload
-      srand(777)
-      second_payload = GovukSchemas::RandomExample.new(schema: schema).payload
-
-      expect(first_payload).to eql(second_payload)
+      # freeze time to avoid inconsistent `public_updated_at` values between runs
+      Timecop.freeze do
+        srand(777) # these srand calls would be in the upstream application
+        first_payload = GovukSchemas::RandomExample.new(schema: schema).payload
+        srand(777)
+        second_payload = GovukSchemas::RandomExample.new(schema: schema).payload
+        expect(first_payload).to eql(second_payload)
+      end
     end
 
     it "can customise the payload" do

--- a/spec/lib/random_example_spec.rb
+++ b/spec/lib/random_example_spec.rb
@@ -25,6 +25,16 @@ RSpec.describe GovukSchemas::RandomExample do
       end
     end
 
+    it "returns the same output if a seed is detected" do
+      schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
+      srand(777) # these srand calls would be in the upstream application
+      first_payload = GovukSchemas::RandomExample.new(schema: schema).payload
+      srand(777)
+      second_payload = GovukSchemas::RandomExample.new(schema: schema).payload
+
+      expect(first_payload).to eql(second_payload)
+    end
+
     it "can customise the payload" do
       schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
 

--- a/spec/lib/random_example_spec.rb
+++ b/spec/lib/random_example_spec.rb
@@ -30,10 +30,8 @@ RSpec.describe GovukSchemas::RandomExample do
       schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
       # freeze time to avoid inconsistent `public_updated_at` values between runs
       Timecop.freeze do
-        srand(777) # these srand calls would be in the upstream application
-        first_payload = GovukSchemas::RandomExample.new(schema: schema).payload
-        srand(777)
-        second_payload = GovukSchemas::RandomExample.new(schema: schema).payload
+        first_payload = GovukSchemas::RandomExample.new(schema: schema, seed: 777).payload
+        second_payload = GovukSchemas::RandomExample.new(schema: schema, seed: 777).payload
         expect(first_payload).to eql(second_payload)
       end
     end

--- a/spec/lib/random_example_spec.rb
+++ b/spec/lib/random_example_spec.rb
@@ -1,4 +1,3 @@
-require "timecop"
 require "spec_helper"
 
 RSpec.describe GovukSchemas::RandomExample do
@@ -28,12 +27,9 @@ RSpec.describe GovukSchemas::RandomExample do
 
     it "returns the same output if a seed is detected" do
       schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
-      # freeze time to avoid inconsistent `public_updated_at` values between runs
-      Timecop.freeze do
-        first_payload = GovukSchemas::RandomExample.new(schema: schema, seed: 777).payload
-        second_payload = GovukSchemas::RandomExample.new(schema: schema, seed: 777).payload
-        expect(first_payload).to eql(second_payload)
-      end
+      first_payload = GovukSchemas::RandomExample.new(schema: schema, seed: 777).payload
+      second_payload = GovukSchemas::RandomExample.new(schema: schema, seed: 777).payload
+      expect(first_payload).to eql(second_payload)
     end
 
     it "can customise the payload" do

--- a/spec/lib/random_schema_generator_spec.rb
+++ b/spec/lib/random_schema_generator_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe GovukSchemas::RandomItemGenerator do
+RSpec.describe GovukSchemas::RandomSchemaGenerator do
   describe "#payload" do
     it "generates an object with a required property" do
       schema = {
@@ -13,7 +13,7 @@ RSpec.describe GovukSchemas::RandomItemGenerator do
         },
       }
 
-      generator = GovukSchemas::RandomItemGenerator.new(schema: schema)
+      generator = GovukSchemas::RandomSchemaGenerator.new(schema: schema)
 
       expect(generator.payload.keys).to include("my_field")
     end
@@ -34,7 +34,7 @@ RSpec.describe GovukSchemas::RandomItemGenerator do
         },
       }
 
-      generator = GovukSchemas::RandomItemGenerator.new(schema: schema)
+      generator = GovukSchemas::RandomSchemaGenerator.new(schema: schema)
 
       expect(generator.payload.keys).to include("my_field")
     end
@@ -59,7 +59,7 @@ RSpec.describe GovukSchemas::RandomItemGenerator do
         },
       }
 
-      generator = GovukSchemas::RandomItemGenerator.new(schema: schema)
+      generator = GovukSchemas::RandomSchemaGenerator.new(schema: schema)
 
       expect(generator.payload.keys).to include("my_field")
     end
@@ -87,7 +87,7 @@ RSpec.describe GovukSchemas::RandomItemGenerator do
         ],
       }
 
-      generator = GovukSchemas::RandomItemGenerator.new(schema: schema)
+      generator = GovukSchemas::RandomSchemaGenerator.new(schema: schema)
 
       expect(generator.payload["my_enum"]).to eq("a")
       expect(generator.payload.keys).to include("my_field")


### PR DESCRIPTION
Make RandomExample/RandomItemGenerator deterministic (use seed)
  
We're now building govuk-developer-docs hourly, but our heavy use
of GovukSchemas::RandomExample is causing ~50,000 line changes
for every commit to gh-pages, despite the underlying schemas
remaining unchanged.

We want the example to be random and schema-validated, but not
necessarily a new random on every build. Hence we would like to
set the 'seed' so that we can predictably execute the same random
generation every time. In theory, this means our gh-pages output
will be identical between builds until an underlying schema changes.

govuk_schemas did not support this out of the box because of its
reliance on SecureRandom, which, as the name implies, does not
allow outside interference/configuration by way of seed values
(it gives a truly random result every time). We don't _need_ a
'secure' random output - just something we can be reasonably
confident will give a different result every time if the seed is
omitted. I've reproduced its 'uuid' and 'hex' methods using arrays
of chars/numbers and the native 'rand' method, which _does_
respect the global seed value.