### PR TITLE
Fix gem publishing portion of Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,50 +2,8 @@
 
 library("govuk")
 
-REPOSITORY = 'govuk_schemas'
-
 node {
-
-  try {
-    stage('Checkout') {
-      checkout scm
-    }
-
-    stage('Clean') {
-      govuk.cleanupGit()
-      govuk.mergeMasterBranch()
-    }
-
-    stage("Set up content schema dependency") {
-      govuk.contentSchemaDependency()
-    }
-
-    stage('Bundle') {
-      echo 'Bundling'
-      sh("bundle install --path ${JENKINS_HOME}/bundles/${JOB_NAME}")
-    }
-
-    stage('Linter') {
-      govuk.lintRuby()
-    }
-
-    stage('Tests') {
-      govuk.setEnvar('RAILS_ENV', 'test')
-      govuk.runTests('spec')
-    }
-
-    if(env.BRANCH_NAME == "master") {
-      stage('Publish Gem') {
-        govuk.publishGem(REPOSITORY, env.BRANCH_NAME)
-      }
-    }
-
-  } catch (e) {
-    currentBuild.result = 'FAILED'
-    step([$class: 'Mailer',
-          notifyEveryUnstableBuild: true,
-          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
-          sendToIndividuals: true])
-    throw e
-  }
+  govuk.buildProject(
+    rubyLintDiff: false,
+  )
 }


### PR DESCRIPTION
govuk-jenkinslib does a lot of what we have defined explicitly,
out of the box. For example, gem publishing will automatically
default to the name of the repository, so we don't need to
specify 'REPOSITORY' globally.

(This PR fixes the fact that Jenkins hasn't published the latest gem to rubygems.org.

`java.lang.NoSuchMethodError: No such DSL method 'publishGem' found among steps`)