### PR TITLE
Fix RandomSchemaGenerator.new always returning equivalent generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.1.1
+
+* Fix RandomSchemaGenerator.new always returning equivalent generators ([#60](https://github.com/alphagov/govuk_schemas/pull/60))
+
 # 4.1.0
 
 * Add `seed` parameter to `GovukSchemas::RandomExample` to make the random behaviour deterministic. Given the same seed, the same randomised outputs will be returned ([#56](https://github.com/alphagov/govuk_schemas/pull/56)).

--- a/lib/govuk_schemas/random_schema_generator.rb
+++ b/lib/govuk_schemas/random_schema_generator.rb
@@ -12,7 +12,7 @@ module GovukSchemas
   class RandomSchemaGenerator
     def initialize(schema:, seed: nil)
       @schema = schema
-      @random = Random.new(seed || rand)
+      @random = Random.new(seed || Random.new_seed)
       @generator = RandomContentGenerator.new(random: @random)
     end
 

--- a/spec/lib/random_schema_generator_spec.rb
+++ b/spec/lib/random_schema_generator_spec.rb
@@ -1,6 +1,24 @@
 require "spec_helper"
 
 RSpec.describe GovukSchemas::RandomSchemaGenerator do
+  describe ".new" do
+    it "returns non-equivalent generators on subsequent calls" do
+      schema = {
+        "type" => "object",
+        "required" => %w[my_field],
+        "properties" => {
+          "my_field" => {
+            "type" => "string",
+          }
+        }
+      }
+      generator1 = GovukSchemas::RandomSchemaGenerator.new(schema: schema)
+      generator2 = GovukSchemas::RandomSchemaGenerator.new(schema: schema)
+
+      expect(generator1.payload).not_to eq(generator2.payload)
+    end
+  end
+
   describe "#payload" do
     it "generates an object with a required property" do
       schema = {


### PR DESCRIPTION
RandomSchemaGenerator.new relies on Kernel#rand to generate a seed if
none is given. However, the values returned are in the range 0...1,
which get rounded to 0 by Random.new, effectively becoming a fixed
constant.

Replace Kernel#rand with Random.new_seed.