### PR TITLE
Add support for time regex string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.2.0
+
+* Add support for generating random HH:MM time strings that match a regex. ([#62](https://github.com/alphagov/govuk_schemas/pull/62))
+
 # 4.1.1
 
 * Fix RandomSchemaGenerator.new always returning equivalent generators ([#60](https://github.com/alphagov/govuk_schemas/pull/60))

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -81,6 +81,8 @@ module GovukSchemas
         Date.today.iso8601
       when "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         Date.today.iso8601
+      when "^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$"
+        Time.now.strftime("%H:%m")
       when "^#.+$"
         anchor
       when "[a-z-]"

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "4.1.1".freeze
+  VERSION = "4.2.0".freeze
 end


### PR DESCRIPTION
This updates the random content generator to support outputting a random HH:MM time string when the regex matches.

This was required to support the new `time_registration` field being added to the protected food & drink names finder: https://github.com/alphagov/govuk-content-schemas/pull/1031/commits/b767b7b55fe970445c8a08be1cee2dc8ae849278

[Example failing build](https://ci.integration.publishing.service.gov.uk/job/search-api/job/deployed-to-production/608/console)

[Trello Card](https://trello.com/c/oedYOWVD/2247-updates-to-protected-food-drink-names-finder)