### PR TITLE
Generate unique items for arrays with the "uniqueItems" property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.3.0
+
+* Generate unique items for arrays with the "uniqueItems" property. ([#63](https://github.com/alphagov/govuk_schemas/pull/63))
+
 # 4.2.0
 
 * Add support for generating random HH:MM time strings that match a regex. ([#62](https://github.com/alphagov/govuk_schemas/pull/62))

--- a/lib/govuk_schemas/random_schema_generator.rb
+++ b/lib/govuk_schemas/random_schema_generator.rb
@@ -116,12 +116,27 @@ module GovukSchemas
     def generate_random_array(props)
       min = props["minItems"] || 0
       max = props["maxItems"] || 10
+      unique = props["uniqueItems"] == true
       num_items = @random.rand(min..max)
+      items = []
+      attempts = 0
+      max_attempts = num_items * 100
 
-      num_items.times.map do
+      until items.length == num_items
         # sometimes arrays don't have `items` specified, not sure if this is a bug
-        generate_value(props["items"] || {})
+        new_value = generate_value(props["items"] || {})
+
+        if unique && items.include?(new_value)
+          attempts += 1
+          raise "Failed to create a unique array item after #{max_attempts} attempts" if attempts >= max_attempts
+          next
+        end
+
+        attempts = 0
+        items << new_value
       end
+
+      items
     end
 
     def generate_random_string(props)

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "4.2.0".freeze
+  VERSION = "4.3.0".freeze
 end


### PR DESCRIPTION
This re-calculates the values of an array if the "uniqueItems" property
is set and a non-unique item has been generated. This has been to help
resolve flaky tests that expect a random array and occasionally fail due
to the generation of an array with collisions.

As there is a risk that this can produce an eternal loop I've put in a
check that if there are very number of attempts to generate the unique
value then it should abort. This does produce a risk of failure if there
is a low amount of variance in the allowed variables.

This is to resolve issues such as:

```
GovukSchemas::InvalidContentGenerated: An invalid content item was generated.

This probably means there's a bug in the generator that causes it to output
invalid values. Below you'll find the generated payload, the validation errors
and the schema that was used.

...

Validation errors:
--------------------------

[
  {
    "schema": "869a7d30-f94e-5044-84e7-dc3c01c8f1ba#",
    "fragment": "#/details/featured_attachments",
    "message": "The property '#/details/featured_attachments' contained duplicated array values in schema 869a7d30-f94e-5044-84e7-dc3c01c8f1ba#",
    "failed_attribute": "UniqueItems"
  },
  {
    "schema": "869a7d30-f94e-5044-84e7-dc3c01c8f1ba",
    "fragment": "#/details/featured_attachments",
    "message": "The property '#/details/featured_attachments' contained duplicated array values in schema 869a7d30-f94e-5044-84e7-dc3c01c8f1ba",
    "failed_attribute": "UniqueItems"
  }
]
```