### PR TITLE
Add support for applications that use Minitest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.4.0
+
+* Adds support for applications that use Minitest by adding an `AssertMatchers` module ([#66](https://github.com/alphagov/govuk_schemas/pull/66))
+
 # 4.3.0
 
 * Generate unique items for arrays with the "uniqueItems" property. ([#63](https://github.com/alphagov/govuk_schemas/pull/63))

--- a/lib/govuk_schemas/assert_matchers.rb
+++ b/lib/govuk_schemas/assert_matchers.rb
@@ -1,0 +1,28 @@
+require "govuk_schemas/validator"
+
+module GovukSchemas
+  module AssertMatchers
+    def assert_valid_against_publisher_schema(payload, schema_name)
+      assert_valid_against_schema(payload, schema_name, "publisher")
+    end
+
+    def assert_valid_against_links_schema(payload, schema_name)
+      assert_valid_against_schema(payload, schema_name, "links")
+    end
+
+    def assert_valid_against_frontend_schema(payload, schema_name)
+      assert_valid_against_schema(payload, schema_name, "frontend")
+    end
+
+    def assert_valid_against_notification_schema(payload, schema_name)
+      assert_valid_against_schema(payload, schema_name, "notification")
+    end
+
+  private
+
+    def assert_valid_against_schema(payload, schema_name, schema_type)
+      validator = GovukSchemas::Validator.new(schema_name, schema_type, payload)
+      assert validator.valid?, validator.error_message
+    end
+  end
+end

--- a/lib/govuk_schemas/rspec_matchers.rb
+++ b/lib/govuk_schemas/rspec_matchers.rb
@@ -1,57 +1,20 @@
+require "govuk_schemas/validator"
+
 module GovukSchemas
   module RSpecMatchers
+
     %w[links frontend publisher notification].each do |schema_type|
       RSpec::Matchers.define "be_valid_against_#{schema_type}_schema".to_sym do |schema_name|
         match do |item|
-          schema = Schema.find(Hash["#{schema_type}_schema".to_sym, schema_name])
-          validator = JSON::Validator.fully_validate(schema, item)
-          validator.empty?
+          @validator = GovukSchemas::Validator.new(schema_name, schema_type, item)
+          @validator.valid?
         end
+
 
         failure_message do |actual|
-          ValidationErrorMessage.new(schema_name, "schema", actual).message
+          @validator.error_message
         end
       end
-    end
-  end
-
-  # @private
-  class ValidationErrorMessage
-    attr_reader :schema_name, :type, :payload
-
-    def initialize(schema_name, type, payload)
-      @schema_name = schema_name
-      @type = type
-      @payload = payload
-    end
-
-    def message
-      <<~DOC
-        expected the payload to be valid against the '#{schema_name}' schema:
-
-        #{formatted_payload}
-
-        Validation errors:
-        #{errors}
-      DOC
-    end
-
-  private
-
-    def errors
-      schema = Schema.find(publisher_schema: schema_name)
-      validator = JSON::Validator.fully_validate(schema, payload)
-      validator.map { |message| "- " + humanized_error(message) }.join("\n")
-    end
-
-    def formatted_payload
-      return payload if payload.is_a?(String)
-
-      JSON.pretty_generate(payload)
-    end
-
-    def humanized_error(message)
-      message.gsub("The property '#/'", "The item")
     end
   end
 end

--- a/lib/govuk_schemas/validator.rb
+++ b/lib/govuk_schemas/validator.rb
@@ -1,0 +1,44 @@
+module GovukSchemas
+  class Validator
+    attr_reader :schema_name, :type, :payload
+
+    def initialize(schema_name, type, payload)
+      @schema_name = schema_name
+      @type = type
+      @payload = payload
+    end
+
+    def valid?
+      errors.empty?
+    end
+
+    def error_message
+      <<~DOC
+        expected the payload to be valid against the '#{schema_name}' schema:
+
+        #{formatted_payload}
+
+        Validation errors:
+        #{errors}
+      DOC
+    end
+
+  private
+
+    def errors
+      schema = Schema.find("#{type}_schema": schema_name)
+      validator = JSON::Validator.fully_validate(schema, payload.to_json)
+      validator.map { |message| "- " + humanized_error(message) }.join("\n")
+    end
+
+    def formatted_payload
+      return payload if payload.is_a?(String)
+
+      JSON.pretty_generate(payload)
+    end
+
+    def humanized_error(message)
+      message.gsub("The property '#/'", "The item")
+    end
+  end
+end

--- a/lib/govuk_schemas/validator.rb
+++ b/lib/govuk_schemas/validator.rb
@@ -39,6 +39,8 @@ module GovukSchemas
 
     def humanized_error(message)
       message.gsub("The property '#/'", "The item")
+             .gsub(/in schema [0-9a-f\-]+/, "")
+             .strip
     end
   end
 end

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "4.3.0".freeze
+  VERSION = "4.4.0".freeze
 end

--- a/spec/lib/assert_matchers_spec.rb
+++ b/spec/lib/assert_matchers_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+require "govuk_schemas/assert_matchers"
+
+RSpec.describe GovukSchemas::AssertMatchers do
+  include GovukSchemas::AssertMatchers
+
+  def assert(boolean, error_message); end
+
+  %w[publisher links frontend notification].each do |schema_type|
+    describe "#assert_valid_against_#{schema_type}_schema" do
+      it "detects an valid schema" do
+        example = GovukSchemas::RandomExample.for_schema("#{schema_type}_schema": "placeholder")
+        validator = GovukSchemas::Validator.new("placeholder", schema_type, example)
+        expect(self).to receive(:assert).with(true, validator.error_message)
+
+        public_send("assert_valid_against_#{schema_type}_schema", example, "placeholder")
+      end
+
+      it "detects an invalid schema" do
+        example = { obviously_invalid: true, second_invalid_attribute: true }
+        validator = GovukSchemas::Validator.new("placeholder", schema_type, example)
+        expect(self).to receive(:assert).with(false, validator.error_message)
+
+        public_send("assert_valid_against_#{schema_type}_schema", example, "placeholder")
+      end
+    end
+  end
+end

--- a/spec/lib/validator_spec.rb
+++ b/spec/lib/validator_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe GovukSchemas::Validator do
   end
 
   describe "#error_message" do
-    let(:expected_error_message) do
+    let(:start_of_error_message) do
       <<~DOC
         expected the payload to be valid against the 'placeholder' schema:
 
@@ -28,15 +28,6 @@ RSpec.describe GovukSchemas::Validator do
         }
 
         Validation errors:
-        - The item did not contain a required property of 'base_path' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
-        - The item did not contain a required property of 'details' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
-        - The item did not contain a required property of 'document_type' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
-        - The item did not contain a required property of 'publishing_app' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
-        - The item did not contain a required property of 'rendering_app' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
-        - The item did not contain a required property of 'routes' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
-        - The item did not contain a required property of 'schema_name' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
-        - The item did not contain a required property of 'title' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
-        - The item contains additional properties ["obviously_invalid"] outside of the schema when none are allowed in schema a6ce2f04-e077-594f-ac8a-864075c96db8
       DOC
     end
 
@@ -44,7 +35,9 @@ RSpec.describe GovukSchemas::Validator do
       example = { obviously_invalid: true }
       validator = described_class.new("placeholder", "publisher", example)
 
-      expect(validator.error_message).to eq expected_error_message
+      expect(validator.error_message).to include start_of_error_message
+      expect(validator.error_message).to match(/- The item did not contain a required property of '([a-z_]+)'/i)
+      expect(validator.error_message).to include('- The item contains additional properties ["obviously_invalid"] outside of the schema when none are allowed')
     end
   end
 end

--- a/spec/lib/validator_spec.rb
+++ b/spec/lib/validator_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+require "govuk_schemas/validator"
+
+RSpec.describe GovukSchemas::Validator do
+  describe "#valid?" do
+    it "detects an valid schema" do
+      example = GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder")
+      validator = described_class.new("placeholder", "publisher", example)
+
+      expect(validator.valid?).to eq true
+    end
+
+    it "detects an invalid schema" do
+      example = { obviously_invalid: true }
+      validator = described_class.new("placeholder", "publisher", example)
+
+      expect(validator.valid?).to eq false
+    end
+  end
+
+  describe "#error_message" do
+    let(:expected_error_message) do
+      <<~DOC
+        expected the payload to be valid against the 'placeholder' schema:
+
+        {
+          "obviously_invalid": true
+        }
+
+        Validation errors:
+        - The item did not contain a required property of 'base_path' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
+        - The item did not contain a required property of 'details' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
+        - The item did not contain a required property of 'document_type' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
+        - The item did not contain a required property of 'publishing_app' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
+        - The item did not contain a required property of 'rendering_app' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
+        - The item did not contain a required property of 'routes' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
+        - The item did not contain a required property of 'schema_name' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
+        - The item did not contain a required property of 'title' in schema a6ce2f04-e077-594f-ac8a-864075c96db8
+        - The item contains additional properties ["obviously_invalid"] outside of the schema when none are allowed in schema a6ce2f04-e077-594f-ac8a-864075c96db8
+      DOC
+    end
+
+    it "constructs an error message based on the schema_name, payload and errors" do
+      example = { obviously_invalid: true }
+      validator = described_class.new("placeholder", "publisher", example)
+
+      expect(validator.error_message).to eq expected_error_message
+    end
+  end
+end


### PR DESCRIPTION
## Description 

At the moment, applications that use Minitest still use the govuk-content-schema-test-helpers gem.

As this has been deprecated, we need to add functionality to ensure that applications that use Minitest can validate objects against the relevant schema.

This PR does a couple of things:

1. pulls out logic around validation of a payload against a schema and error construction into a reusable module
2. uses the module in `RSpecMatchers`
3. adds an `AssertMatchers` module. This allows apps that use Minitest to validate content item payloads against schemas 

## Guidance to review 

If you want to test it works, you can pull down `update-to-use-govuk-schemas-gem` on Whitehall as seen in this PR https://github.com/alphagov/whitehall/pull/6678.

Or on mainstream by pulling down `add-govuk-schemas-gem`  as seen in this PR https://github.com/alphagov/publisher/pull/1634

As the gem is being run locally you'll need to have the govuk_schemas repo in your govuk dir to run the latest unshipped changes in this PR.

## Trello card 

https://trello.com/c/Q9O5rXnz/550-stop-using-the-deprecated-govuk-content-schema-test-helpers-gem