### PR TITLE
Ensure the validator can handle the payload being JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.4.1
+
+* Fix `Validator` module to handle JSON or other object types being passed as the payload ([#68](https://github.com/alphagov/govuk_schemas/pull/68))
+
 # 4.4.0
 
 * Adds support for applications that use Minitest by adding an `AssertMatchers` module ([#66](https://github.com/alphagov/govuk_schemas/pull/66))

--- a/lib/govuk_schemas/validator.rb
+++ b/lib/govuk_schemas/validator.rb
@@ -1,11 +1,12 @@
 module GovukSchemas
   class Validator
-    attr_reader :schema_name, :type, :payload
+    attr_reader :schema_name, :type
+    attr_accessor :payload
 
     def initialize(schema_name, type, payload)
       @schema_name = schema_name
       @type = type
-      @payload = payload
+      @payload = ensure_json(payload)
     end
 
     def valid?
@@ -27,20 +28,24 @@ module GovukSchemas
 
     def errors
       schema = Schema.find("#{type}_schema": schema_name)
-      validator = JSON::Validator.fully_validate(schema, payload.to_json)
+      validator = JSON::Validator.fully_validate(schema, payload)
       validator.map { |message| "- " + humanized_error(message) }.join("\n")
     end
 
     def formatted_payload
-      return payload if payload.is_a?(String)
-
-      JSON.pretty_generate(payload)
+      JSON.pretty_generate(JSON.parse(payload))
     end
 
     def humanized_error(message)
       message.gsub("The property '#/'", "The item")
              .gsub(/in schema [0-9a-f\-]+/, "")
              .strip
+    end
+
+    def ensure_json(payload)
+      return payload if payload.is_a?(String)
+
+      payload.to_json
     end
   end
 end

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "4.4.0".freeze
+  VERSION = "4.4.1".freeze
 end

--- a/spec/lib/validator_spec.rb
+++ b/spec/lib/validator_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe GovukSchemas::Validator do
 
       expect(validator.valid?).to eq false
     end
+
+    it "handles the payload being passed as json" do
+      example = GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder").to_json
+      validator = described_class.new("placeholder", "publisher", example)
+
+      expect(validator.valid?).to eq true
+    end
   end
 
   describe "#error_message" do


### PR DESCRIPTION
## Description

At the moment, there's some disparity between how applications that user Minitest and applications that use RSpec pass their payloads.

RSpec applications pass the payload as JSON and Minitest applications pass it as a Hash.

Currently, the payload is being converted to JSON before being validated by `JSON.fully_validate`. If the object is already JSON then .to_json is called again. This means when JSON.parse is called within `JSON.fully_validate` on the payload it does not convert it to a hash.

This commit updates the validator to ensure that the payload not converted to JSON if it is already a string.

## Trello card 

https://trello.com/c/Q9O5rXnz/550-stop-using-the-deprecated-govuk-content-schema-test-helpers-gem