### PR TITLE
Add Rubocop to the Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "rubocop/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new(:lint)
 
-task default: [:spec]
+task default: %i[lint spec]

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -8,9 +8,10 @@ module GovukSchemas
     end
 
     def string_for_type(type)
-      if type == "date-time"
+      case type
+      when "date-time"
         time
-      elsif type == "uri"
+      when "uri"
         uri
       else
         raise "Unknown attribute type `#{type}`"
@@ -28,7 +29,7 @@ module GovukSchemas
     end
 
     def base_path
-      "/" + @random.rand(1..5).times.map { uuid }.join("/")
+      "/#{@random.rand(1..5).times.map { uuid }.join('/')}"
     end
 
     def govuk_subdomain_url

--- a/lib/govuk_schemas/random_example.rb
+++ b/lib/govuk_schemas/random_example.rb
@@ -90,7 +90,7 @@ module GovukSchemas
         payload = yield(payload)
         # check the payload again after customisation
         errors = validation_errors_for(payload)
-        raise InvalidContentGenerated, error_message(payload, errors, true) if errors.any?
+        raise InvalidContentGenerated, error_message(payload, errors, customised: true) if errors.any?
       end
 
       payload
@@ -102,7 +102,7 @@ module GovukSchemas
       JSON::Validator.fully_validate(@schema, item, errors_as_objects: true)
     end
 
-    def error_message(item, errors, customised = false)
+    def error_message(item, errors, customised: false)
       details = <<~ERR
         Generated payload:
         --------------------------

--- a/lib/govuk_schemas/random_schema_generator.rb
+++ b/lib/govuk_schemas/random_schema_generator.rb
@@ -103,11 +103,7 @@ module GovukSchemas
         next unless should_generate_value
 
         one_of_properties = (one_of_sample["properties"] || {})[attribute_name]
-        document[attribute_name] = if one_of_properties
-                                     generate_value(one_of_properties)
-                                   else
-                                     generate_value(attribute_properties)
-                                   end
+        document[attribute_name] = generate_value(one_of_properties || attribute_properties)
       end
 
       document
@@ -129,6 +125,7 @@ module GovukSchemas
         if unique && items.include?(new_value)
           attempts += 1
           raise "Failed to create a unique array item after #{max_attempts} attempts" if attempts >= max_attempts
+
           next
         end
 

--- a/lib/govuk_schemas/rspec_matchers.rb
+++ b/lib/govuk_schemas/rspec_matchers.rb
@@ -2,7 +2,6 @@ require "govuk_schemas/validator"
 
 module GovukSchemas
   module RSpecMatchers
-
     %w[links frontend publisher notification].each do |schema_type|
       RSpec::Matchers.define "be_valid_against_#{schema_type}_schema".to_sym do |schema_name|
         match do |item|
@@ -10,10 +9,7 @@ module GovukSchemas
           @validator.valid?
         end
 
-
-        failure_message do |actual|
-          @validator.error_message
-        end
+        failure_message { @validator.error_message }
       end
     end
   end

--- a/lib/govuk_schemas/validator.rb
+++ b/lib/govuk_schemas/validator.rb
@@ -29,7 +29,7 @@ module GovukSchemas
     def errors
       schema = Schema.find("#{type}_schema": schema_name)
       validator = JSON::Validator.fully_validate(schema, payload)
-      validator.map { |message| "- " + humanized_error(message) }.join("\n")
+      validator.map { |message| "- #{humanized_error(message)}" }.join("\n")
     end
 
     def formatted_payload

--- a/spec/lib/random_schema_generator_spec.rb
+++ b/spec/lib/random_schema_generator_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe GovukSchemas::RandomSchemaGenerator do
         "properties" => {
           "my_field" => {
             "type" => "string",
-          }
-        }
+          },
+        },
       }
       generator1 = GovukSchemas::RandomSchemaGenerator.new(schema: schema)
       generator2 = GovukSchemas::RandomSchemaGenerator.new(schema: schema)


### PR DESCRIPTION
## Description

At the moment, Rubocop does not run when you run `bundle exec rake` this had led to a few bits of code being merged in that don't follow the conventions set out in `govuk_rubocop`. Nothing massive to worry about, but we should be keeping our codebases consistent.

This adds a lint task to the Rakefile that runs Rubocop and fixes any issues flagged.