### PR TITLE
Add support for schemas in publishing api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Clone govuk-content-schemas
+      - name: Clone content-schemas
         uses: actions/checkout@v2
         with:
-          repository: alphagov/govuk-content-schemas
+          repository: alphagov/publishing-api
           ref: deployed-to-production
-          path: tmp/govuk-content-schemas
+          path: tmp/publishing-api
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake
         env:
-          GOVUK_CONTENT_SCHEMAS_PATH: tmp/govuk-content-schemas
+          GOVUK_CONTENT_SCHEMAS_PATH: tmp/publishing-api/content_schemas
 
   # Branch protection rules cannot directly depend on status checks from matrix jobs.
   # So instead we define `test` as a dummy job which only runs after the preceding `test_matrix` checks have passed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update default content schemas url to point to publishing api rather than govuk-content-schemas. This is because we are merging schemas into publishing api.
 * Update path of allowed_document_types.yml to reflect new location in publishing api, allowing us to remove a symlink.
+* Introduce a setter method for manually configuring the path to schemas, outside of an env variable
 
 # 4.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 
 * Update default content schemas url to point to publishing api rather than govuk-content-schemas. This is because we are merging schemas into publishing api.
+* Update path of allowed_document_types.yml to reflect new location in publishing api, allowing us to remove a symlink.
 
 # 4.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+* Update default content schemas url to point to publishing api rather than govuk-content-schemas. This is because we are merging schemas into publishing api.
+
 # 4.4.1
 
 * Fix `Validator` module to handle JSON or other object types being passed as the payload ([#68](https://github.com/alphagov/govuk_schemas/pull/68))

--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   # This should be kept in sync with the json-schema version of govuk-content-schemas.
   spec.add_dependency "json-schema", ">= 2.8", "< 3.1"
 
+  spec.add_development_dependency "climate_control"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.4"

--- a/lib/govuk_schemas.rb
+++ b/lib/govuk_schemas.rb
@@ -6,7 +6,7 @@ require "govuk_schemas/example"
 
 module GovukSchemas
   # @private
-  CONTENT_SCHEMA_DIR = ENV["GOVUK_CONTENT_SCHEMAS_PATH"] || "../govuk-content-schemas"
+  CONTENT_SCHEMA_DIR = ENV["GOVUK_CONTENT_SCHEMAS_PATH"] || "../publishing-api/content_schemas"
 
   # @private
   class InvalidContentGenerated < RuntimeError

--- a/lib/govuk_schemas.rb
+++ b/lib/govuk_schemas.rb
@@ -5,8 +5,13 @@ require "govuk_schemas/document_types"
 require "govuk_schemas/example"
 
 module GovukSchemas
-  # @private
-  CONTENT_SCHEMA_DIR = ENV["GOVUK_CONTENT_SCHEMAS_PATH"] || "../publishing-api/content_schemas"
+  def self.content_schema_dir=(path_to_schemas)
+    @content_schema_dir = path_to_schemas
+  end
+
+  def self.content_schema_dir
+    @content_schema_dir ||= ENV.fetch("GOVUK_CONTENT_SCHEMAS_PATH", "../publishing-api/content_schemas")
+  end
 
   # @private
   class InvalidContentGenerated < RuntimeError

--- a/lib/govuk_schemas/document_types.rb
+++ b/lib/govuk_schemas/document_types.rb
@@ -3,7 +3,7 @@ module GovukSchemas
     # Return all of the document types on GOV.UK
     def self.valid_document_types
       @valid_document_types ||= begin
-        filename = "#{GovukSchemas::CONTENT_SCHEMA_DIR}/allowed_document_types.yml"
+        filename = "#{GovukSchemas.content_schema_dir}/allowed_document_types.yml"
         YAML.load_file(filename)
       end
     end

--- a/lib/govuk_schemas/document_types.rb
+++ b/lib/govuk_schemas/document_types.rb
@@ -3,7 +3,7 @@ module GovukSchemas
     # Return all of the document types on GOV.UK
     def self.valid_document_types
       @valid_document_types ||= begin
-        filename = "#{GovukSchemas::CONTENT_SCHEMA_DIR}/lib/govuk_content_schemas/allowed_document_types.yml"
+        filename = "#{GovukSchemas::CONTENT_SCHEMA_DIR}/allowed_document_types.yml"
         YAML.load_file(filename)
       end
     end

--- a/lib/govuk_schemas/example.rb
+++ b/lib/govuk_schemas/example.rb
@@ -27,11 +27,11 @@ module GovukSchemas
     # @param schema_name [String] like "detailed_guide", "policy" or "publication"
     # @return [String] the path to use for examples
     def self.examples_path(schema_name)
-      examples_dir = "#{GovukSchemas::CONTENT_SCHEMA_DIR}/examples"
+      examples_dir = "#{GovukSchemas.content_schema_dir}/examples"
       if Dir.exist?(examples_dir)
         "#{examples_dir}/#{schema_name}/frontend"
       else
-        "#{GovukSchemas::CONTENT_SCHEMA_DIR}/formats/#{schema_name}/frontend/examples"
+        "#{GovukSchemas.content_schema_dir}/formats/#{schema_name}/frontend/examples"
       end
     end
   end

--- a/lib/govuk_schemas/schema.rb
+++ b/lib/govuk_schemas/schema.rb
@@ -11,7 +11,7 @@ module GovukSchemas
     #   GovukSchemas::Schema.find(notification_schema: "detailed_guide")
     # @return [Hash] the JSON schema as a hash
     def self.find(schema)
-      file_path = "#{GovukSchemas::CONTENT_SCHEMA_DIR}/dist/formats/#{location_for_schema_name(schema)}"
+      file_path = "#{GovukSchemas.content_schema_dir}/dist/formats/#{location_for_schema_name(schema)}"
       JSON.parse(File.read(file_path))
     end
 
@@ -21,7 +21,7 @@ module GovukSchemas
     # @return [Array<Hash>] List of JSON schemas as hashes
     def self.all(schema_type: "*")
       schema_type = "publisher_v2" if schema_type == "publisher"
-      Dir.glob("#{GovukSchemas::CONTENT_SCHEMA_DIR}/dist/formats/*/#{schema_type}/*.json").each_with_object({}) do |file_path, hash|
+      Dir.glob("#{GovukSchemas.content_schema_dir}/dist/formats/*/#{schema_type}/*.json").each_with_object({}) do |file_path, hash|
         hash[file_path] = JSON.parse(File.read(file_path))
       end
     end
@@ -38,7 +38,7 @@ module GovukSchemas
     #
     # @return [Array] all the schema names
     def self.schema_names
-      Dir.glob("#{GovukSchemas::CONTENT_SCHEMA_DIR}/dist/formats/*").map do |directory|
+      Dir.glob("#{GovukSchemas.content_schema_dir}/dist/formats/*").map do |directory|
         File.basename(directory)
       end
     end

--- a/spec/govuk_schemas_spec.rb
+++ b/spec/govuk_schemas_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe GovukSchemas do
+  around :each do |example|
+    # resets content schema directory before and after each test so that these tests do not affect other tests' state
+    GovukSchemas.content_schema_dir = nil
+    example.run
+    GovukSchemas.content_schema_dir = nil
+  end
+
+  describe "GovukSchemas" do
+    describe ".content_schema_dir" do
+      it "can be manually set" do
+        described_class.content_schema_dir = "/manually/set/path"
+        expect(described_class.content_schema_dir).to eql("/manually/set/path")
+      end
+
+      it "can be set via the GOVUK_CONTENT_SCHEMAS_PATH env variable when no path has been manually set" do
+        ClimateControl.modify GOVUK_CONTENT_SCHEMAS_PATH: "/env/var/path" do
+          expect(described_class.content_schema_dir).to eql("/env/var/path")
+        end
+      end
+
+      it "uses the manually set variable over an environment variable" do
+        ClimateControl.modify GOVUK_CONTENT_SCHEMAS_PATH: "/env/var/path" do
+          described_class.content_schema_dir = "/manually/set/path"
+          expect(described_class.content_schema_dir).to eql("/manually/set/path")
+        end
+      end
+
+      it "uses the default path if no manually configured or env variable path has been set" do
+        ClimateControl.modify GOVUK_CONTENT_SCHEMAS_PATH: nil do
+          expect(described_class.content_schema_dir).to eql("../publishing-api/content_schemas")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/example_spec.rb
+++ b/spec/lib/example_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe GovukSchemas::Example do
     before do
       allow(Dir)
         .to receive(:exist?)
-        .with("#{GovukSchemas::CONTENT_SCHEMA_DIR}/examples")
+        .with("#{GovukSchemas.content_schema_dir}/examples")
         .and_return(in_examples)
     end
 
@@ -32,12 +32,12 @@ RSpec.describe GovukSchemas::Example do
 
     context "when schema examples are in /examples" do
       let(:in_examples) { true }
-      it { is_expected.to eq "#{GovukSchemas::CONTENT_SCHEMA_DIR}/examples/#{schema_name}/frontend" }
+      it { is_expected.to eq "#{GovukSchemas.content_schema_dir}/examples/#{schema_name}/frontend" }
     end
 
     context "when schema examples are not in /examples" do
       let(:in_examples) { false }
-      it { is_expected.to eq "#{GovukSchemas::CONTENT_SCHEMA_DIR}/formats/#{schema_name}/frontend/examples" }
+      it { is_expected.to eq "#{GovukSchemas.content_schema_dir}/formats/#{schema_name}/frontend/examples" }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "govuk_schemas"
 require "pry-byebug"
+require "climate_control"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Content schemas have now been merged into publishing api. This PR contains a few small changes that support the transition of content schemas into publishing api and away from govuk_content_schemas:

1. The default path for schemas (used when neither the setter introduced below nor the environment variable are configured) has been updated to reflect their new location in publishing api. This will mean that *local* development will take place against the schemas in publishing api.

2. Updates the path used for the 'allowed_document_types' file to reflect its new location in publishing api (a symlink currently exists in publishing api to support the existing path)

3. A setter has been introduced to allow for manually configuring the path to schemas upon startup of an application, as opposed to via an environment variable. This removes some weirdness for publishing api since schemas were merged into it where publishing api a) relied on an environment variable configured outside the application to read from its own schemas for deployed versions; and b) would rely on a default path "../publishing-api/content_schemas" for local development which looked one directory up and then pointed back at itself. This has been implemented as a non- breaking change.

[Trello](https://trello.com/c/ZUK2duYI/361-add-govuk-content-schemas-to-publishing-api-repo)