### PR TITLE
Release version 4.5.0 of govuk schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# UNRELEASED
+# 4.5.0
 
+General support for content schemas in publishing api:
 * Update default content schemas url to point to publishing api rather than govuk-content-schemas. This is because we are merging schemas into publishing api.
 * Update path of allowed_document_types.yml to reflect new location in publishing api, allowing us to remove a symlink.
 * Introduce a setter method for manually configuring the path to schemas, outside of an env variable

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GOV.UK Schemas
 
-Gem to work with the [govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas).
+Gem to work with the [schemas in publishing api](https://github.com/alphagov/publishing-api/tree/main/content_schemas).
 
 ## Installation
 
@@ -16,7 +16,7 @@ gem "govuk_schemas", "~> VERSION"
 
 ## Running the test suite
 
-Make sure you have `govuk-content-schemas` cloned in a sibling directory:
+Make sure you have `publishing-api` cloned in a sibling directory:
 
 ```
 bundle exec rake

--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  # This should be kept in sync with the json-schema version of govuk-content-schemas.
+  # This should be kept in sync with the json-schema version of publishing-api.
   spec.add_dependency "json-schema", ">= 2.8", "< 3.1"
 
   spec.add_development_dependency "climate_control"

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -102,7 +102,7 @@ module GovukSchemas
         raise <<-DOC
           Don't know how to generate random string for pattern #{pattern.inspect}
 
-          This propably means you've introduced a new regex in  govuk-content-schemas.
+          This propably means you've introduced a new regex in  publishing api.
           Because it's very hard to generate a valid string from a regex alone,
           we have to specify a method to generate random data for each regex in
           the schemas.

--- a/lib/govuk_schemas/random_example.rb
+++ b/lib/govuk_schemas/random_example.rb
@@ -9,7 +9,7 @@ module GovukSchemas
   #
   # - The gem doesn't support `patternProperties` yet. On GOV.UK we [use this in
   # the expanded frontend
-  # links](https://github.com/alphagov/govuk-content-schemas/blob/bdd97d18c7a9318e66f332f0748a410fddab1141/formats/frontend_links_definition.json#L67-L71).
+  # links](https://github.com/alphagov/publishing-api/blob/a8039d430e44c86c3f54a69569f07ad48a4fc912/content_schemas/formats/shared/definitions/frontend_links.jsonnet#L118-L121).
   # - It's complicated to generate random data for `oneOf` properties. According
   # to the JSON Schema spec a `oneOf` schema is only valid if the data is valid
   # against *only one* of the clauses. To do this properly, we'd have to make

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "4.4.1".freeze
+  VERSION = "4.5.0".freeze
 end


### PR DESCRIPTION
This adds general support for schemas in publishing api, rather than a separate repo.

None of the changes are breaking, although it will mean that developers need an up-to-date version of publishing api locally (rather than govuk-content-schemas)

[Trello](https://trello.com/c/ZUK2duYI/361-add-govuk-content-schemas-to-publishing-api-repo)