### PR TITLE
Dependabot to monitor GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: "github-actions"
+    directory: /
+    schedule:
+      interval: daily

--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.4"
-  spec.add_development_dependency "rubocop-govuk", "~> 4.0"
+  spec.add_development_dependency "rubocop-govuk", "4.9.0"
   spec.add_development_dependency "yard", "~> 0.8"
 
   spec.required_ruby_version = ">= 2.6"

--- a/lib/govuk_schemas/validator.rb
+++ b/lib/govuk_schemas/validator.rb
@@ -38,7 +38,7 @@ module GovukSchemas
 
     def humanized_error(message)
       message.gsub("The property '#/'", "The item")
-             .gsub(/in schema [0-9a-f\-]+/, "")
+             .gsub(/in schema [0-9a-f-]+/, "")
              .strip
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

This will open PRs when the actions used are updated.