### PR TITLE
Test against Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [ 2.7, '3.0', 3.1 ]
+        ruby: [2.7, '3.0', 3.1, 3.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Ruby 3.2 was released on December 25th 2022