### PR TITLE
Bump `yard` gem to 0.9.20

### DIFF
--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rubocop-govuk", "4.10.0"
-  spec.add_development_dependency "yard", "~> 0.8"
+  spec.add_development_dependency "yard", "~> 0.9.20"
 
   spec.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
There are two security vulnerabilities in the currently installed version of yard [1] and [2].

Therefore bumping the gem to the minimum version that includes patches for these issues.

1: https://github.com/alphagov/govuk_schemas/security/dependabot/1
2: https://github.com/alphagov/govuk_schemas/security/dependabot/2

[Trello card](https://trello.com/c/rAFOShCp)