### PR TITLE
Remove `yard` dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 /.bundle/
-/.yardoc
 /Gemfile.lock
-/_yardoc/
 /coverage/
 /doc/
 /pkg/

--- a/README.md
+++ b/README.md
@@ -22,12 +22,6 @@ Make sure you have `publishing-api` cloned in a sibling directory:
 bundle exec rake
 ```
 
-### Documentation
-
-To run a Yard server locally to preview documentation, run:
-
-    $ bundle exec yard server --reload
-
 ## License
 
 The gem is available as open source under the terms of the [MIT License](LICENCE).

--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rubocop-govuk", "4.10.0"
-  spec.add_development_dependency "yard", "~> 0.8"
 
   spec.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION
There are two security vulnerabilities in the currently installed version of yard [1] and [2].

This gem was being used solely to run a local version of the application, however we don't believe anyone is actually doing this.

Therefore removing the dependency.

1: https://github.com/alphagov/govuk_schemas/security/dependabot/1
2: https://github.com/alphagov/govuk_schemas/security/dependabot/2

[Trello card](https://trello.com/c/rAFOShCp)