### PR TITLE
Add missing regex generator for specialist_documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## Unreleased
+# 4.6.0
 
 * Drop support for Ruby 2.7.
+* Fix guidance on fixing a regex issue to reference correct filename.
+* Add support for `^[1-9][0-9]{3}$` regex to resolve exceptions randomly generating specialist_documents.
 
 # 4.5.0
 

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -102,14 +102,13 @@ module GovukSchemas
         raise <<-DOC
           Don't know how to generate random string for pattern #{pattern.inspect}
 
-          This propably means you've introduced a new regex in  publishing api.
-          Because it's very hard to generate a valid string from a regex alone,
-          we have to specify a method to generate random data for each regex in
-          the schemas.
+          This probably means you've introduced a new regex in to a content
+          schema in Publishing API. Because it's very hard to generate a valid
+          string from a regex alone, we have to specify a method to generate
+          random data for each regex in the schemas.
 
-          To fix this:
-
-          - Add your regex to `lib/govuk_schemas/random.rb`
+          This can be fixed by adding your regex to `lib/govuk_schemas/random_content_generator.rb`
+          in https://github.com/alphagov/govuk_schemas
         DOC
       end
     end

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -84,6 +84,8 @@ module GovukSchemas
         Date.today.iso8601
       when "^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$"
         Time.now.strftime("%H:%m")
+      when "^[1-9][0-9]{3}$"
+        rand(1000...9999).to_s
       when "^#.+$"
         anchor
       when "[a-z-]"

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -99,7 +99,7 @@ module GovukSchemas
       when '[a-z0-9\-_]'
         "#{hex}-#{hex}"
       else
-        raise <<-DOC
+        raise <<~DOC
           Don't know how to generate random string for pattern #{pattern.inspect}
 
           This probably means you've introduced a new regex in to a content

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "4.5.0".freeze
+  VERSION = "4.6.0".freeze
 end


### PR DESCRIPTION
This adds a new regex to the random content generator to resolve errors generating random `specialist_document` schemas. Example error:

```
  1) GovukIndex::ElasticsearchPresenter Specialist formats statutory instrument
     Failure/Error:
       example = GovukSchemas::RandomExample.for_schema(notification_schema: "specialist_document") do |payload|
         payload["details"]["metadata"] = metadata
         payload
       end

     RuntimeError:
                 Don't know how to generate random string for pattern "^[1-9][0-9]{3}$"

                 This propably means you've introduced a new regex in  publishing api.
                 Because it's very hard to generate a valid string from a regex alone,
                 we have to specify a method to generate random data for each regex in
                 the schemas.

                 To fix this:

                 - Add your regex to `lib/govuk_schemas/random.rb`
```

This PR also improves the message above to be:

```
Don't know how to generate random string for pattern "^[1-9][0-9]{3}$"

This probably means you've introduced a new regex in to a content
schema in Publishing API. Because it's very hard to generate a valid
string from a regex alone, we have to specify a method to generate
random data for each regex in the schemas.

This can be fixed by adding your regex to `lib/govuk_schemas/random_content_generator.rb`
in https://github.com/alphagov/govuk_schemas
```

And finally, bumps the version number