### PR TITLE
CI approach to match current convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,14 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'The branch, tag or SHA to checkout'
+        default: main
+        type: string
 
 jobs:
   # This matrix job runs the test suite against multiple Ruby versions
@@ -11,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - name: Clone content-schemas
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: alphagov/publishing-api
-          ref: deployed-to-production
+          ref: main
           path: tmp/publishing-api
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This fixes a couple of cases where the CI approach for this repo was behind GOV.UK's conventions:

1. It replaces the use of "deployed-to-production" for cloning Publishing API, which is no longer updated since the Kubernetes platform was launched.
2. It updates the triggering of CI actions to match GOV.UK GitHub Action conventions: https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#when-the-ci-workflow-should-run