### PR TITLE
Release version 4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.7.0
+
+* Update `json-schema` dependency.
+
 # 4.6.0
 
 * Drop support for Ruby 2.7.

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "4.6.0".freeze
+  VERSION = "4.7.0".freeze
 end


### PR DESCRIPTION
This releases the change in https://github.com/alphagov/govuk_schemas/pull/90.

Required to allow us to upgrade `json-schema` in Publishing API: https://github.com/alphagov/publishing-api/pull/2507/files