### PR TITLE
Use "generic" schema in place of old "placeholder"

### DIFF
--- a/spec/lib/assert_matchers_spec.rb
+++ b/spec/lib/assert_matchers_spec.rb
@@ -9,19 +9,19 @@ RSpec.describe GovukSchemas::AssertMatchers do
   %w[publisher links frontend notification].each do |schema_type|
     describe "#assert_valid_against_#{schema_type}_schema" do
       it "detects an valid schema" do
-        example = GovukSchemas::RandomExample.for_schema("#{schema_type}_schema": "placeholder")
-        validator = GovukSchemas::Validator.new("placeholder", schema_type, example)
+        example = GovukSchemas::RandomExample.for_schema("#{schema_type}_schema": "generic")
+        validator = GovukSchemas::Validator.new("generic", schema_type, example)
         expect(self).to receive(:assert).with(true, validator.error_message)
 
-        public_send("assert_valid_against_#{schema_type}_schema", example, "placeholder")
+        public_send("assert_valid_against_#{schema_type}_schema", example, "generic")
       end
 
       it "detects an invalid schema" do
         example = { obviously_invalid: true, second_invalid_attribute: true }
-        validator = GovukSchemas::Validator.new("placeholder", schema_type, example)
+        validator = GovukSchemas::Validator.new("generic", schema_type, example)
         expect(self).to receive(:assert).with(false, validator.error_message)
 
-        public_send("assert_valid_against_#{schema_type}_schema", example, "placeholder")
+        public_send("assert_valid_against_#{schema_type}_schema", example, "generic")
       end
     end
   end

--- a/spec/lib/random_example_spec.rb
+++ b/spec/lib/random_example_spec.rb
@@ -3,13 +3,13 @@ require "spec_helper"
 RSpec.describe GovukSchemas::RandomExample do
   describe ".for_schema" do
     it "returns a random example for a schema" do
-      example = GovukSchemas::RandomExample.for_schema(frontend_schema: "placeholder")
+      example = GovukSchemas::RandomExample.for_schema(frontend_schema: "generic")
 
       expect(example).to be_a(Hash)
     end
 
     it "can be customised" do
-      example = GovukSchemas::RandomExample.for_schema(frontend_schema: "placeholder") do |hash|
+      example = GovukSchemas::RandomExample.for_schema(frontend_schema: "generic") do |hash|
         hash.merge("base_path" => "/some-base-path")
       end
 

--- a/spec/lib/rspec_matchers_spec.rb
+++ b/spec/lib/rspec_matchers_spec.rb
@@ -6,29 +6,29 @@ RSpec.describe GovukSchemas::RSpecMatchers do
 
   describe "#be_valid_against_publisher_schema" do
     it "detects an valid schema" do
-      example = GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder")
+      example = GovukSchemas::RandomExample.for_schema(publisher_schema: "generic")
 
-      expect(example).to be_valid_against_publisher_schema("placeholder")
+      expect(example).to be_valid_against_publisher_schema("generic")
     end
 
     it "detects an invalid schema" do
       example = { obviously_invalid: true }
 
-      expect(example).to_not be_valid_against_publisher_schema("placeholder")
+      expect(example).to_not be_valid_against_publisher_schema("generic")
     end
   end
 
   describe "#be_valid_against_links_schema" do
     it "detects an valid schema for links" do
-      example = GovukSchemas::RandomExample.for_schema(links_schema: "placeholder")
+      example = GovukSchemas::RandomExample.for_schema(links_schema: "generic")
 
-      expect(example).to be_valid_against_links_schema("placeholder")
+      expect(example).to be_valid_against_links_schema("generic")
     end
 
     it "detects an invalid schema for links" do
       example = { obviously_invalid: true }
 
-      expect(example).to_not be_valid_against_links_schema("placeholder")
+      expect(example).to_not be_valid_against_links_schema("generic")
     end
   end
 end

--- a/spec/lib/validator_spec.rb
+++ b/spec/lib/validator_spec.rb
@@ -4,22 +4,22 @@ require "govuk_schemas/validator"
 RSpec.describe GovukSchemas::Validator do
   describe "#valid?" do
     it "detects an valid schema" do
-      example = GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder")
-      validator = described_class.new("placeholder", "publisher", example)
+      example = GovukSchemas::RandomExample.for_schema(publisher_schema: "generic")
+      validator = described_class.new("generic", "publisher", example)
 
       expect(validator.valid?).to eq true
     end
 
     it "detects an invalid schema" do
       example = { obviously_invalid: true }
-      validator = described_class.new("placeholder", "publisher", example)
+      validator = described_class.new("generic", "publisher", example)
 
       expect(validator.valid?).to eq false
     end
 
     it "handles the payload being passed as json" do
-      example = GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder").to_json
-      validator = described_class.new("placeholder", "publisher", example)
+      example = GovukSchemas::RandomExample.for_schema(publisher_schema: "generic").to_json
+      validator = described_class.new("generic", "publisher", example)
 
       expect(validator.valid?).to eq true
     end
@@ -28,7 +28,7 @@ RSpec.describe GovukSchemas::Validator do
   describe "#error_message" do
     let(:start_of_error_message) do
       <<~DOC
-        expected the payload to be valid against the 'placeholder' schema:
+        expected the payload to be valid against the 'generic' schema:
 
         {
           "obviously_invalid": true
@@ -40,7 +40,7 @@ RSpec.describe GovukSchemas::Validator do
 
     it "constructs an error message based on the schema_name, payload and errors" do
       example = { obviously_invalid: true }
-      validator = described_class.new("placeholder", "publisher", example)
+      validator = described_class.new("generic", "publisher", example)
 
       expect(validator.error_message).to include start_of_error_message
       expect(validator.error_message).to match(/- The item did not contain a required property of '([a-z_]+)'/i)


### PR DESCRIPTION
The "placeholder" schema was removed a while ago
(https://github.com/alphagov/publishing-api/pull/2493) with the intention of specs switching to using the "generic" one