### PR TITLE
Avoid double validation of payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Improve speed of random schema generation for customised content items
+
 # 5.0.0
 
 * BREAKING: Drop support for Ruby 3.0. The minimum required Ruby version is now 3.1.4.

--- a/lib/govuk_schemas/random_example.rb
+++ b/lib/govuk_schemas/random_example.rb
@@ -29,7 +29,8 @@ module GovukSchemas
     #     GovukSchemas::RandomExample.new(schema: schema, seed: 777).payload
     #     GovukSchemas::RandomExample.new(schema: schema, seed: 777).payload # returns same as above
     #
-    # @param [Hash] schema A JSON schema.
+    # @param [Hash]         schema  A JSON schema.
+    # @param [Integer, nil] seed    A random number seed for deterministic results
     # @return [GovukSchemas::RandomExample]
     def initialize(schema:, seed: nil)
       @schema = schema
@@ -54,8 +55,6 @@ module GovukSchemas
     # @param [Block] the base payload is passed inton the block, with the block result then becoming
     #   the new payload. The new payload is then validated. (optional)
     # @return [GovukSchemas::RandomExample]
-    # @param [Block] the base payload is passed inton the block, with the block result then becoming
-    #   the new payload. The new payload is then validated. (optional)
     def self.for_schema(schema_key_value, &block)
       schema = GovukSchemas::Schema.find(schema_key_value)
       GovukSchemas::RandomExample.new(schema:).payload(&block)

--- a/spec/lib/random_example_spec.rb
+++ b/spec/lib/random_example_spec.rb
@@ -32,34 +32,44 @@ RSpec.describe GovukSchemas::RandomExample do
       expect(first_payload).to eql(second_payload)
     end
 
-    it "can customise the payload" do
-      schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
+    it "raises an error if the generated schema is invalid" do
+      generator = instance_double(GovukSchemas::RandomSchemaGenerator, payload: {})
+      allow(GovukSchemas::RandomSchemaGenerator).to receive(:new).and_return(generator)
 
-      example = GovukSchemas::RandomExample.new(schema:).payload do |hash|
-        hash.merge("base_path" => "/some-base-path")
+      schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
+      expect { GovukSchemas::RandomExample.new(schema:).payload }
+        .to raise_error(GovukSchemas::InvalidContentGenerated)
+    end
+
+    context "when the payload is customised" do
+      it "returns the customised payload" do
+        schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
+
+        example = GovukSchemas::RandomExample.new(schema:).payload do |hash|
+          hash.merge("base_path" => "/some-base-path")
+        end
+
+        expect(example["base_path"]).to eql("/some-base-path")
       end
 
-      expect(example["base_path"]).to eql("/some-base-path")
-    end
+      it "raises if the resulting content item won't be valid" do
+        schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
 
-    it "failes when attempting to edit the hash in place" do
-      schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
+        expect {
+          GovukSchemas::RandomExample.new(schema:).payload do |hash|
+            hash.merge("base_path" => nil)
+          end
+        }.to raise_error(GovukSchemas::InvalidContentGenerated, /The item was valid before being customised/)
+      end
 
-      expect {
-        GovukSchemas::RandomExample.new(schema:).payload do |hash|
-          hash["base_path"] = "/some-base-path"
-        end
-      }.to raise_error(GovukSchemas::InvalidContentGenerated)
-    end
+      it "raises if the non-customised content item was invalid" do
+        generator = instance_double(GovukSchemas::RandomSchemaGenerator, payload: {})
+        allow(GovukSchemas::RandomSchemaGenerator).to receive(:new).and_return(generator)
 
-    it "raises if the resulting content item won't be valid" do
-      schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
-
-      expect {
-        GovukSchemas::RandomExample.new(schema:).payload do |hash|
-          hash.merge("base_path" => nil)
-        end
-      }.to raise_error(GovukSchemas::InvalidContentGenerated)
+        schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
+        expect { GovukSchemas::RandomExample.new(schema:).payload { |h| h.merge("base_path" => "/test") } }
+          .to raise_error(GovukSchemas::InvalidContentGenerated, /An invalid content item was generated/)
+      end
     end
   end
 end


### PR DESCRIPTION
The call to validate a schema is quite expensive:

```
[3] pry(#<GovukSchemas::RandomExample>)> puts Benchmark.measure { 100.times { JSON::Validator.fully_validate(@Schema, item, errors_as_objects: true) } }
  7.614167   1.532485   9.146652 ( 10.468765)
```

This updates the code to avoid making two calls to the validator when a
payload is generated with a block if the customised version is valid.

Before:

```
irb(main):010:0> puts Benchmark.measure { 100.times { GovukSchemas::RandomExample.for_schema(frontend_schema: "news_artic
le") { |schema| schema["title"] = "Custom"; schema } } }
 13.308641   3.087679  16.396320 ( 18.977005)
```

After:

```
irb(main):002:0> puts Benchmark.measure { 100.times { GovukSchemas::RandomExample.for_schema(frontend_schema: "news_artic
le") { |schema| schema["title"] = "Custom"; schema } } }
  7.654303   1.561620   9.215923 ( 10.604802)
```

The motivation for this was that the GOV.UK Chat test suite makes quite
heavy use of random schemas with customisations for checking supported
schemas. On a MBP with GOV.UK Docker this reduces the time of the
running the test suite from around ~55s to around ~35s.