### PR TITLE
Fix incorrect error for invalid customised payload 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 5.0.2
 
 * Fix issue where customised schema validation message was incorrect for a modified payload
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix issue where customised schema validation message was incorrect for a modified payload
+
 # 5.0.1
 
 * Improve speed of random schema generation for customised content items

--- a/lib/govuk_schemas/random_example.rb
+++ b/lib/govuk_schemas/random_example.rb
@@ -93,7 +93,8 @@ module GovukSchemas
   private
 
     def customise_payload(payload)
-      original_payload = payload
+      # Use Marshal to create a deep dup of the payload so the original can be mutated
+      original_payload = Marshal.load(Marshal.dump(payload))
       customised_payload = yield(payload)
       customised_errors = validation_errors_for(customised_payload)
 

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "5.0.1".freeze
+  VERSION = "5.0.2".freeze
 end

--- a/spec/lib/random_example_spec.rb
+++ b/spec/lib/random_example_spec.rb
@@ -62,6 +62,17 @@ RSpec.describe GovukSchemas::RandomExample do
         }.to raise_error(GovukSchemas::InvalidContentGenerated, /The item was valid before being customised/)
       end
 
+      it "raises when modifying the hash directly creates an invalid content item" do
+        schema = GovukSchemas::Schema.random_schema(schema_type: "frontend")
+
+        expect {
+          GovukSchemas::RandomExample.new(schema:).payload do |hash|
+            hash["base_path"] = nil
+            hash
+          end
+        }.to raise_error(GovukSchemas::InvalidContentGenerated, /The item was valid before being customised/)
+      end
+
       it "raises if the non-customised content item was invalid" do
         generator = instance_double(GovukSchemas::RandomSchemaGenerator, payload: {})
         allow(GovukSchemas::RandomSchemaGenerator).to receive(:new).and_return(generator)


### PR DESCRIPTION
The change in https://github.com/alphagov/govuk_schemas/pull/113 didn't handle a common usage scenario where a user modifies the payload passed into the block (example usage [1]).

In order to handle this we need to make a copy of the original payload before it is modified. As this project doesn't have an ActiveSupport dependency I wrote the equivalent of a deep_dup method. using `Marshal.load(Marshal.dump(object))`, with an expectation that given the data generated is JSON in a Ruby Hash/Array structure there'd be no risk of objects not having Marshal support.

An earlier approach was to iterate ourselves, but that was a bit more verbose:

```
    def deep_dup_payload(item)
      case item
      when Array
        item.map { |i| deep_dup_payload(i) }
      when Hash
        item.dup.transform_values { |v| deep_dup_payload(v) }
      else
        item.dup
      end
    end
```

Anecdotally it does seem that previously this project considered modifying the payload as unsupported [2], but this wasn't enforced by a frozen object and would now be a breaking change to require this.

[1]: https://github.com/alphagov/content-data-api/blob/cddc744baa0a073868a527b5513a7943fa53ddc6/spec/factories/messages.rb#L19-L26
[2]: https://github.com/alphagov/govuk_schemas/blob/e1da17587b10df8ae3b29d7583c3a4881a377f97/spec/lib/random_example_spec.rb#L45-L53
