### PR TITLE
Support email addresses

### DIFF
--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json-schema", ">= 2.8", "< 4.4"
 
   spec.add_development_dependency "climate_control"
+  spec.add_development_dependency "faker", "~> 3.4.1"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.4"

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -1,3 +1,5 @@
+require "faker"
+
 module GovukSchemas
   # @private
   class RandomContentGenerator
@@ -13,6 +15,8 @@ module GovukSchemas
         time
       when "uri"
         uri
+      when "email"
+        Faker::Internet.email
       else
         raise "Unknown attribute type `#{type}`"
       end

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -29,7 +29,7 @@ module GovukSchemas
 
     # TODO: make this more random with query string, optional anchor.
     def uri
-      "http://example.com#{base_path}#{anchor}"
+      "#{Faker::Internet.url(path: base_path)}#{anchor}"
     end
 
     def base_path
@@ -37,10 +37,8 @@ module GovukSchemas
     end
 
     def govuk_subdomain_url
-      subdomain = @random.rand(2..4).times.map {
-        ("a".."z").to_a.sample(@random.rand(3..8), random: @random).join
-      }.join(".")
-      "https://#{subdomain}.gov.uk#{base_path}"
+      host = Faker::Internet.domain_name(subdomain: true, domain: "gov.uk")
+      Faker::Internet.url(host:, path: base_path)
     end
 
     def string(minimum_chars = nil, maximum_chars = nil)

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -7,6 +7,7 @@ module GovukSchemas
 
     def initialize(random: Random.new)
       @random = random
+      Faker::Config.random = @random
     end
 
     def string_for_type(type)

--- a/lib/govuk_schemas/random_content_generator.rb
+++ b/lib/govuk_schemas/random_content_generator.rb
@@ -18,7 +18,17 @@ module GovukSchemas
       when "email"
         Faker::Internet.email
       else
-        raise "Unknown attribute type `#{type}`"
+        raise <<~DOC
+           Unsupported JSON schema type `#{type}`
+
+           Supported formats are:
+             - date-time
+             - uri
+             - email
+
+           This can be fixed by adding a type to the `string_for_type` method in
+          `lib/govuk_schemas/random_content_generator.rb` in https://github.com/alphagov/govuk_schemas
+        DOC
       end
     end
 

--- a/spec/lib/random_content_generator_spec.rb
+++ b/spec/lib/random_content_generator_spec.rb
@@ -8,4 +8,15 @@ RSpec.describe GovukSchemas::RandomContentGenerator do
       expect(string).to be_a(String)
     end
   end
+
+  describe ".string_for_type" do
+    it "generates an email address" do
+      email = "foo@example.com"
+      allow(Faker::Internet).to receive(:email) { email }
+
+      response = GovukSchemas::RandomContentGenerator.new.string_for_type("email")
+
+      expect(response).to eq(email)
+    end
+  end
 end

--- a/spec/lib/random_content_generator_spec.rb
+++ b/spec/lib/random_content_generator_spec.rb
@@ -19,4 +19,38 @@ RSpec.describe GovukSchemas::RandomContentGenerator do
       expect(response).to eq(email)
     end
   end
+
+  describe ".uri" do
+    it "generates a url" do
+      random_content_generator = GovukSchemas::RandomContentGenerator.new
+      url = "http://example.com"
+      base_path = "foo/bar"
+      anchor = "#foo"
+
+      allow(Faker::Internet).to receive(:url).with(path: base_path) { url }
+      allow(random_content_generator).to receive(:base_path) { base_path }
+      allow(random_content_generator).to receive(:anchor) { "#foo" }
+
+      response = random_content_generator.uri
+
+      expect(response).to eq("#{url}#{anchor}")
+    end
+  end
+
+  describe ".govuk_subdomain_url" do
+    it "generates a uri" do
+      random_content_generator = GovukSchemas::RandomContentGenerator.new
+      host = "http://foo.gov.uk"
+      base_path = "foo/bar"
+      url = "#{host}/#{base_path}"
+
+      allow(Faker::Internet).to receive(:domain_name).with(subdomain: true, domain: "gov.uk") { host }
+      allow(random_content_generator).to receive(:base_path) { base_path }
+      allow(Faker::Internet).to receive(:url).with(host:, path: base_path) { url }
+
+      response = random_content_generator.govuk_subdomain_url
+
+      expect(response).to eq(url)
+    end
+  end
 end

--- a/spec/lib/random_content_generator_spec.rb
+++ b/spec/lib/random_content_generator_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe GovukSchemas::RandomContentGenerator do
 
       expect(response).to eq(email)
     end
+
+    it "raises an error if the type is not present" do
+      expect {
+        GovukSchemas::RandomContentGenerator.new.string_for_type("duration")
+      }.to raise_error(/Unsupported JSON schema type `duration`/)
+    end
   end
 
   describe ".uri" do


### PR DESCRIPTION
This adds support for the `email` format, as [defined in JSON schema](https://json-schema.org/understanding-json-schema/reference/string#email-addresses). I've also used the [Faker gem](https://github.com/faker-ruby/faker) to allow us to generate random emails and URLs. We could do more with this to simplify the `RandomContentGenerator` code and give us more random data, but let's stick to Internet-related stuff for now. 