### PR TITLE
Faker should be a non-development dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.0.4
+
+* Ensure `Faker` is added as a non-development dependency 
+
 # 5.0.3
 
 * Add support for `email` string types

--- a/govuk_schemas.gemspec
+++ b/govuk_schemas.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
+  spec.add_dependency "faker", "~> 3.4.1"
   # This should be kept in sync with the json-schema version of publishing-api.
   spec.add_dependency "json-schema", ">= 2.8", "< 4.4"
 
   spec.add_development_dependency "climate_control"
-  spec.add_development_dependency "faker", "~> 3.4.1"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.4"

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "5.0.3".freeze
+  VERSION = "5.0.4".freeze
 end


### PR DESCRIPTION
We should have added this as a dependency for all environments, so the dependency gets pulled in when installing the gem 🤦 