### PR TITLE
Switch out testing specialist document schema type

### DIFF
--- a/spec/lib/example_spec.rb
+++ b/spec/lib/example_spec.rb
@@ -3,16 +3,16 @@ require "spec_helper"
 RSpec.describe GovukSchemas::Example do
   describe ".find_all" do
     it "returns all the examples" do
-      examples = GovukSchemas::Example.find_all("specialist_document")
+      examples = GovukSchemas::Example.find_all("call_for_evidence")
 
       expect(examples).to be_a(Array)
-      expect(examples.size > 10).to eql(true)
+      expect(examples.size > 1).to eql(true)
     end
   end
 
   describe ".find" do
     it "returns one example" do
-      example_content_item = GovukSchemas::Example.find("specialist_document", example_name: "drug-safety-update")
+      example_content_item = GovukSchemas::Example.find("call_for_evidence", example_name: "call_for_evidence_outcome")
 
       expect(example_content_item).to be_a(Hash)
     end
@@ -20,7 +20,7 @@ RSpec.describe GovukSchemas::Example do
 
   describe ".examples_path" do
     let(:in_examples) { false }
-    let(:schema_name) { "specialist_document" }
+    let(:schema_name) { "call_for_evidence" }
     before do
       allow(Dir)
         .to receive(:exist?)


### PR DESCRIPTION
Specialist documents example schemas change often and are high cost to maintain. we should avoid using manually maintained examples for specialist documents and generate them from RandomExample as much as we can. This should allow us to purge some of the example schemas for specialist documents in Publishing API.

https://trello.com/c/7fzxocSX/2813-remove-specialist-document-examples-from-publishing-api