### PR TITLE
PP-7281 Introduce a "one of everything" strategy for `RandomSchemaGenerator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Introduce a "one of everything" strategy for RandomSchemaGenerator https://github.com/alphagov/govuk_schemas/pull/168
+
 ## 6.0.0
 
 * BREAKING: Drop support for Ruby 3.1 [PR](https://github.com/alphagov/govuk_schemas/pull/141)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 6.1.0
 
 * Introduce a "one of everything" strategy for RandomSchemaGenerator https://github.com/alphagov/govuk_schemas/pull/168
 

--- a/lib/govuk_schemas/random_example.rb
+++ b/lib/govuk_schemas/random_example.rb
@@ -31,10 +31,11 @@ module GovukSchemas
     #
     # @param [Hash]         schema  A JSON schema.
     # @param [Integer, nil] seed    A random number seed for deterministic results
+    # @param [Symbol] strategy    The generation strategy for RandomSchemaGenerator to use
     # @return [GovukSchemas::RandomExample]
-    def initialize(schema:, seed: nil)
+    def initialize(schema:, seed: nil, strategy: nil)
       @schema = schema
-      @random_generator = RandomSchemaGenerator.new(schema:, seed:)
+      @random_generator = RandomSchemaGenerator.new(schema:, seed:, strategy:)
     end
 
     # Returns a new `GovukSchemas::RandomExample` object.
@@ -53,12 +54,13 @@ module GovukSchemas
     #
     # @param schema_key_value [Hash]
     # @param [Integer] seed The seed for RandomSchemaGenerator's random functions
+    # @param [Symbol] strategy The generation strategy for RandomSchemaGenerator to use
     # @param [Block] the base payload is passed inton the block, with the block result then becoming
     #   the new payload. The new payload is then validated. (optional)
     # @return [GovukSchemas::RandomExample]
-    def self.for_schema(seed: nil, **schema_key_value, &block)
+    def self.for_schema(seed: nil, strategy: nil, **schema_key_value, &block)
       schema = GovukSchemas::Schema.find(schema_key_value)
-      GovukSchemas::RandomExample.new(schema:, seed:).payload(&block)
+      GovukSchemas::RandomExample.new(schema:, seed:, strategy:).payload(&block)
     end
 
     # Return a content item merged with a hash and with the excluded fields removed.

--- a/lib/govuk_schemas/random_example.rb
+++ b/lib/govuk_schemas/random_example.rb
@@ -52,12 +52,13 @@ module GovukSchemas
     #      # => {"base_path"=>"Test base path", "title"=>"dolor est...", "publishing_app"=>"elit"...}
     #
     # @param schema_key_value [Hash]
+    # @param [Integer] seed The seed for RandomSchemaGenerator's random functions
     # @param [Block] the base payload is passed inton the block, with the block result then becoming
     #   the new payload. The new payload is then validated. (optional)
     # @return [GovukSchemas::RandomExample]
-    def self.for_schema(schema_key_value, &block)
+    def self.for_schema(seed: nil, **schema_key_value, &block)
       schema = GovukSchemas::Schema.find(schema_key_value)
-      GovukSchemas::RandomExample.new(schema:).payload(&block)
+      GovukSchemas::RandomExample.new(schema:, seed:).payload(&block)
     end
 
     # Return a content item merged with a hash and with the excluded fields removed.

--- a/lib/govuk_schemas/random_schema_generator.rb
+++ b/lib/govuk_schemas/random_schema_generator.rb
@@ -94,11 +94,11 @@ module GovukSchemas
         # populate all of the keys in the hash. This isn't quite random, but I
         # haven't found a nice way yet to ensure there's at least n elements in
         # the hash.
-        should_generate_value = @generator.bool \
-          || subschema["required"].to_a.include?(attribute_name) \
-          || (one_of_sample["required"] || {}).to_a.include?(attribute_name) \
-          || (one_of_sample["properties"] || {}).keys.include?(attribute_name) \
-          || subschema["minProperties"] \
+        should_generate_value = @generator.bool ||
+          subschema["required"].to_a.include?(attribute_name) ||
+          (one_of_sample["required"] || {}).to_a.include?(attribute_name) ||
+          (one_of_sample["properties"] || {}).keys.include?(attribute_name) ||
+          subschema["minProperties"]
 
         next unless should_generate_value
 

--- a/lib/govuk_schemas/random_schema_generator.rb
+++ b/lib/govuk_schemas/random_schema_generator.rb
@@ -10,6 +10,9 @@ module GovukSchemas
   #
   # @private
   class RandomSchemaGenerator
+    DEFAULT_MIN_ITEMS = 0
+    DEFAULT_MAX_ITEMS = 10
+
     def initialize(schema:, seed: nil)
       @schema = schema
       @random = Random.new(seed || Random.new_seed)
@@ -109,9 +112,17 @@ module GovukSchemas
       document
     end
 
+    def min_items_for_array(array_properties)
+      array_properties["minItems"] || DEFAULT_MIN_ITEMS
+    end
+
+    def max_items_for_array(array_properties)
+      array_properties["maxItems"] || DEFAULT_MAX_ITEMS
+    end
+
     def generate_random_array(props)
-      min = props["minItems"] || 0
-      max = props["maxItems"] || 10
+      min = min_items_for_array(props)
+      max = max_items_for_array(props)
       unique = props["uniqueItems"] == true
       num_items = @random.rand(min..max)
       items = []

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "6.0.0".freeze
+  VERSION = "6.1.0".freeze
 end

--- a/spec/lib/random_example_spec.rb
+++ b/spec/lib/random_example_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe GovukSchemas::RandomExample do
 
       expect(example["base_path"]).to eql("/some-base-path")
     end
+
+    it "can be supplied a random seed to be passed onto RandomSchemaGenerator" do
+      example = GovukSchemas::RandomExample.for_schema(
+        frontend_schema: "generic",
+        seed: 777,
+      )
+
+      expect(example).to be_a(Hash)
+    end
   end
 
   describe "#payload" do


### PR DESCRIPTION
Introduce a "one of everything" strategy for `RandomSchemaGenerator`, resulting in a content item that has a value for all required properties, optional properties and a single item in every array.

This feature is useful for our work generating GraphQL queries based on content schemas. Without optional properties and arrays populated, the resulting GraphQL query will be missing essential fields.