### PR TITLE
[PP-7588] Update logic for identifying path definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.3.1
+
+* Update logic for identifying path definitions
+
 ## 6.3.0
 
 * Drop support for Ruby 3.2

--- a/lib/govuk_schemas/random_schema_generator.rb
+++ b/lib/govuk_schemas/random_schema_generator.rb
@@ -70,6 +70,10 @@ module GovukSchemas
         # validate against the other schemas in `props['oneOf']`.
         generate_value(props["oneOf"].sample(random: @random))
       elsif props["allOf"]
+        if props["$ref"] == "#/definitions/absolute_path"
+          return generate_random_string(props["allOf"].first)
+        end
+
         props["allOf"].each_with_object({}) do |subschema, hash|
           val = generate_value(subschema)
           hash.merge(val)

--- a/lib/govuk_schemas/version.rb
+++ b/lib/govuk_schemas/version.rb
@@ -1,4 +1,4 @@
 module GovukSchemas
   # @private
-  VERSION = "6.3.0".freeze
+  VERSION = "6.3.1".freeze
 end

--- a/spec/lib/random_content_generator_spec.rb
+++ b/spec/lib/random_content_generator_spec.rb
@@ -55,9 +55,19 @@ RSpec.describe GovukSchemas::RandomContentGenerator do
   end
 
   describe ".string_for_regex" do
+    let(:random_content_generator) { GovukSchemas::RandomContentGenerator.new }
+
+    it "generates a valid base path" do
+      input_pattern = "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+      additional_required_pattern = "^/.{0,511}$"
+      result = random_content_generator.string_for_regex(input_pattern)
+
+      expect(result).to match(/#{input_pattern}/)
+      expect(result).to match(/#{additional_required_pattern}/)
+    end
+
     it "generates a content block order item" do
       pattern = "^addresses|contact_links|email_addresses|telephones.[a-z0-9]+(?:-[a-z0-9]+)*$"
-      random_content_generator = GovukSchemas::RandomContentGenerator.new
       result = random_content_generator.string_for_regex(pattern)
 
       expect(result).to match(/#{pattern}/)

--- a/spec/lib/random_schema_generator_spec.rb
+++ b/spec/lib/random_schema_generator_spec.rb
@@ -111,6 +111,43 @@ RSpec.describe GovukSchemas::RandomSchemaGenerator do
       expect(generator.payload.keys).to include("my_field")
     end
 
+    it "handles base paths using allOf property" do
+      schema = {
+        "type" => "object",
+        "required" => %w[base_path],
+        "properties" => {
+          "base_path" => { "$ref" => "#/definitions/absolute_path" },
+        },
+        "definitions" => {
+          "absolute_path" => {
+            "allOf" => [
+              {
+                "type" => "string",
+                "pattern" => "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$",
+                "description" => "A path only. Query string and/or fragment are not allowed.",
+              },
+              {
+                "type" => "string",
+                "pattern" => "^/.{0,511}$",
+                "description" => "A path only. Query string and/or fragment are not allowed.",
+              },
+            ],
+          },
+        },
+      }
+
+      content_generator = GovukSchemas::RandomContentGenerator.new
+      allow(content_generator)
+        .to receive(:string_for_regex)
+        .with("^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$")
+        .and_return("/valid/content")
+      allow(GovukSchemas::RandomContentGenerator).to receive(:new)
+        .and_return(content_generator)
+      generator = GovukSchemas::RandomSchemaGenerator.new(schema:)
+
+      expect(generator.payload).to include("base_path" => "/valid/content")
+    end
+
     describe "unique arrays" do
       it "handles arrays that require unique items" do
         schema = {


### PR DESCRIPTION
We're introducing a new restriction on base paths in Publishing API, including via the content schemas. This new restriction will be enforced alongside the current one by using the "allOf" JSON schema feature

We currently have some logic for handling fields using "allOf", but it assumes that you want an object/hash and that the "allOf" array will contain object definitions. This was introduced in https://github.com/alphagov/govuk_schemas/commit/6b6319f5db6ecc77607680ef2fd9e32c0b88f18a. It looks like this was used in two schemas in the archived govuk_content_schemas repo but was removed in https://github.com/alphagov/govuk-content-schemas/commit/d3e77d7dea495b7946cb91384ca2654bb63c1086 and hasn't been used since moving the content schemas into Publishing API

The current method of generating a base path in RandomContentGenerator produces base paths that will still be valid with the new restriction, so the easiest way to get things working here is to include a condition specifically targeting "absolute_path" definitions, which is what's done here. This is currently inside the "allOf" branch to ensure compatibility with the current non-"allOf" definition, but once the content schema change is merged it could live outside of this (the content schema change needs to be merged second because of tests in Publishing API that rely on this code

It might be worth separately reviewing the assumptions and use cases around "allOf", possibly removing it from the conditional flow or raising an exception if it's found for anything other than absolute_path. The latter would make fewer assumptions about future use cases, and ensure we do the work to handle things properly when introducing it (rather than falling back on the else condition)